### PR TITLE
Improve Supabase auth edge cases

### DIFF
--- a/lib/component/onboarding_screens/onboarding_screen.dart
+++ b/lib/component/onboarding_screens/onboarding_screen.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../home_screen.dart';
+import '../../services/auth_service.dart';
+import '../../pages/auth/auth_page.dart';
 import 'first_screen.dart';
 import 'second_screen.dart';
 import 'third_screen.dart';
@@ -27,12 +29,37 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setBool('showHome', true);
     if (!mounted) return;
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(
-        builder: (context) => HomeScreen(),
-      ),
-    );
+    final authService = AuthService();
+    await authService.ready();
+
+    if (authService.isAuthenticated || !authService.canAttemptAuthentication) {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (context) => const HomeScreen(),
+        ),
+      );
+    } else {
+      Navigator.pushReplacement(
+        context,
+        MaterialPageRoute(
+          builder: (context) => AuthPage(
+            showAppBar: false,
+            allowSkip: true,
+            onAuthenticated: (ctx) {
+              Navigator.of(ctx).pushReplacement(
+                MaterialPageRoute(builder: (_) => const HomeScreen()),
+              );
+            },
+            onSkip: (ctx) {
+              Navigator.of(ctx).pushReplacement(
+                MaterialPageRoute(builder: (_) => const HomeScreen()),
+              );
+            },
+          ),
+        ),
+      );
+    }
   }
 
   @override

--- a/lib/pages/settings/profile_settings.dart
+++ b/lib/pages/settings/profile_settings.dart
@@ -1,20 +1,15 @@
-import 'package:flutter/material.dart';
+import 'dart:convert';
 import 'dart:io';
+
+import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-// import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:provider/provider.dart';
+
+import '../../services/auth_service.dart';
 import '../auth/auth_page.dart';
-import '../auth/user_survey_page.dart';
-// import '../../services/auth_service.dart';
-import '../../services/local_db_service.dart';
-import 'dart:ui';
-import 'package:shared_preferences/shared_preferences.dart';
-import 'package:path_provider/path_provider.dart';
-import 'package:path/path.dart' as path;
 
 extension StringExtension on String {
-  String capitalize() {
-    return "${this[0].toUpperCase()}${substring(1)}";
-  }
+  String capitalize() => isEmpty ? this : '${this[0].toUpperCase()}${substring(1)}';
 }
 
 class ProfileSettingsPage extends StatefulWidget {
@@ -25,369 +20,351 @@ class ProfileSettingsPage extends StatefulWidget {
 }
 
 class _ProfileSettingsPageState extends State<ProfileSettingsPage> {
-  bool _isLoggedIn = false;
-  File? _profileImageFile;
-  String? _profileImageUrl;
-  String? _username;
-  String? _email;
-  DateTime? _signupDate;
-  String? _profession;
-  String? _fullName;
-  DateTime? _dateOfBirth;
-  String? _heardFrom;
   bool _isLoading = false;
+  File? _localAvatarFile;
   final ImagePicker _picker = ImagePicker();
-  // final _authService = AuthService();
-  // final _supabase = Supabase.instance.client;
-  final _localDBService = LocalDBService();
-  User? _userData;
 
   @override
   void initState() {
     super.initState();
-    _loadUserData();
+    Future.microtask(_refreshProfile);
   }
 
-  Future<void> _loadUserData() async {
-    setState(() {
-      _isLoading = true;
-    });
+  Future<void> _refreshProfile() async {
+    final authService = context.read<AuthService>();
+    setState(() => _isLoading = true);
+    await authService.refreshProfile();
+    if (mounted) {
+      setState(() => _isLoading = false);
+    }
+  }
 
-    try {
-      final currentUser = _localDBService.currentUser;
-      
-      if (currentUser != null) {
-        setState(() {
-          _isLoggedIn = true;
-          _email = currentUser.email;
-          _username = currentUser.username;
-          _profileImageUrl = currentUser.avatarUrl;
-          _profession = currentUser.profession;
-          _signupDate = currentUser.createdAt;
-          _fullName = currentUser.fullName;
-          _dateOfBirth = currentUser.dateOfBirth;
-          _userData = currentUser;
-          
-          // If avatar URL is a local file path, create File object
-          if (_profileImageUrl != null && _profileImageUrl!.isNotEmpty) {
-            _profileImageFile = File(_profileImageUrl!);
-          }
-        });
-      } else {
-        setState(() {
-          _isLoggedIn = false;
-        });
+  ImageProvider? _resolveAvatar(UserProfile? profile) {
+    if (_localAvatarFile != null) {
+      return FileImage(_localAvatarFile!);
+    }
+    final avatarUrl = profile?.avatarUrl;
+    if (avatarUrl == null || avatarUrl.isEmpty) {
+      return null;
+    }
+    if (avatarUrl.startsWith('asset:')) {
+      return AssetImage(avatarUrl.substring(6));
+    }
+    if (avatarUrl.startsWith('data:image')) {
+      final parts = avatarUrl.split(',');
+      if (parts.length == 2) {
+        try {
+          final bytes = base64Decode(parts.last);
+          return MemoryImage(bytes);
+        } catch (_) {}
       }
-    } catch (e) {
-      print('Error loading user data: $e');
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error loading profile: ${e.toString()}')),
-      );
-    } finally {
-      setState(() {
-        _isLoading = false;
-      });
+    } else if (avatarUrl.startsWith('http')) {
+      return NetworkImage(avatarUrl);
+    } else if (File(avatarUrl).existsSync()) {
+      return FileImage(File(avatarUrl));
     }
+    return null;
   }
 
-  Future<void> _pickImage() async {
-    final XFile? image = await _picker.pickImage(source: ImageSource.gallery);
-    if (image != null) {
-      setState(() {
-        _isLoading = true;
-      });
-      
-      try {
-        final currentUser = _localDBService.currentUser;
-        if (currentUser != null) {
-          // Copy the selected image to app documents directory
-          final appDir = await getApplicationDocumentsDirectory();
-          final fileName = 'profile_${currentUser.id}_${DateTime.now().millisecondsSinceEpoch}.jpg';
-          final savedImagePath = path.join(appDir.path, fileName);
-          
-          // Copy the image
-          final File imageFile = File(image.path);
-          await imageFile.copy(savedImagePath);
-
-          // Update user profile with new image path
-          await _localDBService.updateUserProfile(
-            userId: currentUser.id,
-            avatarUrl: savedImagePath,
-          );
-
-          setState(() {
-            _profileImageFile = File(savedImagePath);
-            _profileImageUrl = savedImagePath;
-          });
-          
-          ScaffoldMessenger.of(context).showSnackBar(
-            const SnackBar(
-              content: Text('Profile image updated'),
-              backgroundColor: Color(0xFF8B5CF6),
-            ),
-          );
-        }
-      } catch (e) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error uploading image: ${e.toString()}')),
-        );
-      } finally {
-        setState(() {
-          _isLoading = false;
-        });
-      }
-    }
-  }
-
-  Future<void> _signOut() async {
-    setState(() {
-      _isLoading = true;
-    });
-    
-    try {
-      await _localDBService.logout();
-      setState(() {
-        _isLoggedIn = false;
-        _email = null;
-        _username = null;
-        _profileImageFile = null;
-        _profileImageUrl = null;
-        _profession = null;
-        _signupDate = null;
-        _fullName = null;
-        _dateOfBirth = null;
-        _heardFrom = null;
-      });
-      
-      ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Successfully signed out')),
-      );
-    } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error signing out: ${e.toString()}')),
-      );
-    } finally {
-      setState(() {
-        _isLoading = false;
-      });
-    }
-  }
-
-  void _handleLoginSuccess(String email) {
-    setState(() {
-      _email = email;
-      _isLoggedIn = true;
-    });
-    _loadUserData();
-  }
-
-  Widget _buildLoggedInView() {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16.0),
-      child: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          Center(
-            child: Column(
-              children: [
-                GestureDetector(
-                  onTap: _pickImage,
-                  child: Stack(
-                    children: [
-                      CircleAvatar(
-                        radius: 60,
-                        backgroundColor: Colors.grey[200],
-                        backgroundImage: _profileImageFile != null
-                            ? FileImage(_profileImageFile!)
-                            : null,
-                        child: (_profileImageFile == null)
-                            ? const Icon(Icons.person, size: 60, color: Colors.grey)
-                            : null,
-                      ),
-                      Positioned(
-                        bottom: 0,
-                        right: 0,
-                        child: Container(
-                          padding: const EdgeInsets.all(4),
-                          decoration: const BoxDecoration(
-                            color: Color(0xFF8B5CF6),
-                            shape: BoxShape.circle,
-                          ),
-                          child: const Icon(
-                            Icons.camera_alt,
-                            color: Colors.white,
-                            size: 20,
-                          ),
-                        ),
-                      ),
-                    ],
-                  ),
-                ),
-                const SizedBox(height: 16),
-                Text(
-                  _username ?? 'Username',
-                  style: const TextStyle(
-                    fontSize: 24,
-                    fontWeight: FontWeight.bold,
-                  ),
-                ),
-                Text(
-                  _email ?? 'Email',
-                  style: TextStyle(
-                    fontSize: 16,
-                    color: Colors.grey[600],
-                  ),
-                ),
-              ],
-            ),
-          ),
-          const SizedBox(height: 32),
-          _buildSectionTitle('Personal Information'),
-          const SizedBox(height: 16),
-          _buildEditableField(
-            label: 'Full Name',
-            value: _userData?.fullName ?? '',
-            onEdit: () => _editField('full_name', _userData?.fullName ?? ''),
-          ),
-          _buildEditableField(
-            label: 'Username',
-            value: _userData?.username ?? '',
-            onEdit: () => _editField('username', _userData?.username ?? ''),
-          ),
-          _buildEditableField(
-            label: 'Bio',
-            value: _userData?.bio ?? '',
-            onEdit: () => _editField('bio', _userData?.bio ?? ''),
-          ),
-          _buildEditableField(
-            label: 'Date of Birth',
-            value: _userData?.dateOfBirth != null ? _formatDate(_userData!.dateOfBirth!.toIso8601String()) : '',
-            onEdit: () => _selectDate(context),
-          ),
-          _buildEditableField(
-            label: 'Profession',
-            value: _userData?.profession ?? '',
-            onEdit: () => _editField('profession', _userData?.profession ?? ''),
-          ),
-          const SizedBox(height: 32),
-          _buildSectionTitle('Account Settings'),
-          const SizedBox(height: 16),
-          _buildSettingsItem(
-            icon: Icons.email_outlined,
-            title: 'Change Email',
-            onTap: () => _editField('email', _userData?.email ?? ''),
-          ),
-          _buildSettingsItem(
-            icon: Icons.lock_outline,
-            title: 'Change Password',
-            onTap: _changePassword,
-          ),
-          _buildSettingsItem(
-            icon: Icons.delete_outline,
-            title: 'Delete Account',
-            onTap: _deleteAccount,
-            isDestructive: true,
-          ),
-          const SizedBox(height: 32),
-          Center(
-            child: ElevatedButton(
-              onPressed: _isLoading ? null : () async {
-                final shouldLogout = await showDialog<bool>(
-                  context: context,
-                  builder: (context) => AlertDialog(
-                    title: const Text('Logout'),
-                    content: const Text('Are you sure you want to logout?'),
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(12),
-                    ),
-                    actions: [
-                      TextButton(
-                        onPressed: () => Navigator.pop(context, false),
-                        child: Text(
-                          'Cancel',
-                          style: TextStyle(color: Colors.grey[700]),
-                        ),
-                      ),
-                      ElevatedButton(
-                        onPressed: () => Navigator.pop(context, true),
-                        style: ElevatedButton.styleFrom(
-                          backgroundColor: const Color(0xFF8B5CF6),
-                          foregroundColor: Colors.white,
-                        ),
-                        child: const Text('Logout'),
-                      ),
-                    ],
-                  ),
-                );
-              
-                if (shouldLogout == true) {
-                  setState(() => _isLoading = true);
-                  try {
-                    await _signOut();
-                    if (!mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Logged out successfully'),
-                        backgroundColor: Color(0xFF8B5CF6),
-                      ),
-                    );
-                  } catch (e) {
-                    if (!mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Error logging out: $e'),
-                        backgroundColor: Colors.red,
-                      ),
-                    );
-                  } finally {
-                    if (mounted) setState(() => _isLoading = false);
-                  }
-                }
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF8B5CF6),
-                foregroundColor: Colors.white,
-                padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
-                shape: RoundedRectangleBorder(
-                  borderRadius: BorderRadius.circular(12),
-                ),
-                elevation: 2,
-              ),
-              child: _isLoading
-                ? const SizedBox(
-                    width: 20,
-                    height: 20,
-                    child: CircularProgressIndicator(
-                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
-                      strokeWidth: 2,
-                    ),
-                  )
-                : const Row(
-                    mainAxisSize: MainAxisSize.min,
-                    children: [
-                      Icon(Icons.logout, size: 20),
-                      SizedBox(width: 8),
-                      Text(
-                        'Logout',
-                        style: TextStyle(fontSize: 16),
-                      ),
-                    ],
-                  ),
-            ),
-          ),
-          const SizedBox(height: 32),
-        ],
+  void _showSnack(String message, {Color color = const Color(0xFF8B5CF6)}) {
+    if (!mounted) return;
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(
+        content: Text(message),
+        backgroundColor: color,
       ),
     );
   }
 
-  Widget _buildSectionTitle(String title) {
-    return Text(
-      title,
-      style: const TextStyle(
-        fontSize: 18,
-        fontWeight: FontWeight.bold,
-        color: Color(0xFF8B5CF6),
+  Future<void> _pickImage(UserProfile profile) async {
+    final image = await _picker.pickImage(source: ImageSource.gallery, maxWidth: 600, maxHeight: 600);
+    if (image == null) return;
+    try {
+      setState(() => _isLoading = true);
+      final file = File(image.path);
+      final bytes = await file.readAsBytes();
+      final encoded = base64Encode(bytes);
+      await context.read<AuthService>().updateProfile(
+            avatarUrl: 'data:image/jpeg;base64,$encoded',
+          );
+      await context.read<AuthService>().refreshProfile();
+      setState(() {
+        _localAvatarFile = file;
+        _isLoading = false;
+      });
+      _showSnack('Profile image updated');
+    } catch (error) {
+      if (mounted) setState(() => _isLoading = false);
+      _showSnack('Error uploading image: $error', color: Colors.red);
+    }
+  }
+
+  Future<void> _updateProfile({
+    String? fullName,
+    String? username,
+    String? bio,
+    DateTime? dateOfBirth,
+    String? profession,
+  }) async {
+    try {
+      setState(() => _isLoading = true);
+      await context.read<AuthService>().updateProfile(
+            fullName: fullName,
+            username: username,
+            bio: bio,
+            dateOfBirth: dateOfBirth,
+            profession: profession,
+          );
+      await context.read<AuthService>().refreshProfile();
+      setState(() => _isLoading = false);
+      _showSnack('Profile updated successfully');
+    } catch (error) {
+      if (mounted) setState(() => _isLoading = false);
+      _showSnack('Error updating profile: $error', color: Colors.red);
+    }
+  }
+
+  void _promptForValue({
+    required String label,
+    required String initialValue,
+    required Future<void> Function(String value) onSubmit,
+    int maxLines = 1,
+  }) {
+    final controller = TextEditingController(text: initialValue);
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: Text('Edit ${label.capitalize()}'),
+          content: TextField(
+            controller: controller,
+            maxLines: maxLines,
+            decoration: InputDecoration(
+              hintText: 'Enter ${label.replaceAll('_', ' ')}',
+              border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+            ),
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                if (controller.text.trim().isEmpty) {
+                  _showSnack('Value cannot be empty', color: Colors.red);
+                  return;
+                }
+                Navigator.pop(context);
+                await onSubmit(controller.text.trim());
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF8B5CF6),
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Save'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Future<void> _selectDate(UserProfile profile) async {
+    final picked = await showDatePicker(
+      context: context,
+      initialDate: profile.dateOfBirth ?? DateTime(2000),
+      firstDate: DateTime(1900),
+      lastDate: DateTime.now(),
+      builder: (context, child) {
+        return Theme(
+          data: ThemeData.light().copyWith(
+            colorScheme: const ColorScheme.light(
+              primary: Color(0xFF8B5CF6),
+            ),
+          ),
+          child: child!,
+        );
+      },
+    );
+    if (picked != null) {
+      await _updateProfile(dateOfBirth: picked);
+    }
+  }
+
+  Future<void> _changePassword() async {
+    final currentController = TextEditingController();
+    final newController = TextEditingController();
+    final confirmController = TextEditingController();
+
+    showDialog(
+      context: context,
+      builder: (context) {
+        return AlertDialog(
+          title: const Text('Change Password'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              _buildPasswordField('Current Password', currentController),
+              const SizedBox(height: 12),
+              _buildPasswordField('New Password', newController),
+              const SizedBox(height: 12),
+              _buildPasswordField('Confirm New Password', confirmController),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                if (newController.text != confirmController.text) {
+                  _showSnack('New passwords do not match', color: Colors.red);
+                  return;
+                }
+                Navigator.pop(context);
+                final result = await context.read<AuthService>().changePassword(
+                      currentPassword: currentController.text,
+                      newPassword: newController.text,
+                    );
+                _showSnack(
+                  result.message ?? (result.success ? 'Password changed' : 'Password change failed'),
+                  color: result.success ? const Color(0xFF8B5CF6) : Colors.red,
+                );
+              },
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFF8B5CF6),
+                foregroundColor: Colors.white,
+              ),
+              child: const Text('Change Password'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  TextField _buildPasswordField(String label, TextEditingController controller) {
+    return TextField(
+      controller: controller,
+      obscureText: true,
+      decoration: InputDecoration(
+        labelText: label,
+        border: OutlineInputBorder(borderRadius: BorderRadius.circular(12)),
+      ),
+    );
+  }
+
+  Future<void> _requestDeletion() async {
+    final confirm = await showDialog<bool>(
+      context: context,
+      builder: (context) => AlertDialog(
+        title: const Text('Delete Account'),
+        content: const Text(
+          'Your account will be scheduled for deletion in 30 days. '
+          'If you sign in during this period the deletion will be cancelled automatically.',
+        ),
+        actions: [
+          TextButton(
+            onPressed: () => Navigator.pop(context, false),
+            child: const Text('Cancel'),
+          ),
+          ElevatedButton(
+            onPressed: () => Navigator.pop(context, true),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: Colors.red,
+              foregroundColor: Colors.white,
+            ),
+            child: const Text('Schedule Deletion'),
+          ),
+        ],
+      ),
+    );
+
+    if (confirm == true) {
+      await context.read<AuthService>().requestAccountDeletion();
+      await context.read<AuthService>().refreshProfile();
+      _showSnack('Account deletion scheduled. We will remove your data in 30 days unless you sign in again.');
+      setState(() {});
+    }
+  }
+
+  Future<void> _cancelDeletion() async {
+    await context.read<AuthService>().cancelAccountDeletion();
+    await context.read<AuthService>().refreshProfile();
+    _showSnack('Deletion request cancelled');
+    setState(() {});
+  }
+
+  Future<void> _signOut() async {
+    setState(() => _isLoading = true);
+    await context.read<AuthService>().signOut();
+    setState(() {
+      _localAvatarFile = null;
+      _isLoading = false;
+    });
+    _showSnack('Signed out');
+  }
+
+  String _formatDate(DateTime? date) {
+    if (date == null) return 'Not set';
+    return '${date.day}/${date.month}/${date.year}';
+  }
+
+  String _formatDuration(Duration duration) {
+    final days = duration.inDays;
+    final hours = duration.inHours % 24;
+    if (days > 0) {
+      return '$days day${days == 1 ? '' : 's'}${hours > 0 ? ' and $hours hour${hours == 1 ? '' : 's'}' : ''}';
+    }
+    if (hours > 0) {
+      final minutes = duration.inMinutes % 60;
+      return '$hours hour${hours == 1 ? '' : 's'}${minutes > 0 ? ' and $minutes minute${minutes == 1 ? '' : 's'}' : ''}';
+    }
+    final minutes = duration.inMinutes;
+    return minutes > 0 ? '$minutes minute${minutes == 1 ? '' : 's'}' : 'less than a minute';
+  }
+
+  Widget _buildDeletionBanner(UserProfile profile) {
+    if (!profile.hasPendingDeletion) {
+      return const SizedBox.shrink();
+    }
+    final remaining = profile.timeUntilDeletion;
+    final remainingText = remaining == null ? 'less than 30 days' : _formatDuration(remaining);
+    return Container(
+      margin: const EdgeInsets.symmetric(vertical: 12),
+      padding: const EdgeInsets.all(16),
+      decoration: BoxDecoration(
+        color: Colors.red.withOpacity(0.1),
+        borderRadius: BorderRadius.circular(12),
+        border: Border.all(color: Colors.redAccent),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Account deletion scheduled',
+            style: TextStyle(
+              color: Colors.red[700],
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+          const SizedBox(height: 8),
+          Text(
+            'Your account will be permanently deleted in $remainingText.',
+            style: TextStyle(color: Colors.red[700]),
+          ),
+          const SizedBox(height: 12),
+          OutlinedButton(
+            onPressed: _isLoading ? null : _cancelDeletion,
+            style: OutlinedButton.styleFrom(
+              foregroundColor: Colors.red[700],
+              side: BorderSide(color: Colors.red[700] ?? Colors.red),
+            ),
+            child: const Text('Cancel deletion'),
+          ),
+        ],
       ),
     );
   }
@@ -395,12 +372,12 @@ class _ProfileSettingsPageState extends State<ProfileSettingsPage> {
   Widget _buildEditableField({
     required String label,
     required String value,
-    required VoidCallback onEdit,
+    required VoidCallback onTap,
   }) {
     return Padding(
       padding: const EdgeInsets.only(bottom: 16.0),
       child: InkWell(
-        onTap: onEdit,
+        onTap: _isLoading ? null : onTap,
         borderRadius: BorderRadius.circular(12),
         child: Container(
           padding: const EdgeInsets.all(16),
@@ -448,7 +425,7 @@ class _ProfileSettingsPageState extends State<ProfileSettingsPage> {
   Widget _buildSettingsItem({
     required IconData icon,
     required String title,
-    required VoidCallback onTap,
+    VoidCallback? onTap,
     bool isDestructive = false,
   }) {
     return Padding(
@@ -492,353 +469,175 @@ class _ProfileSettingsPageState extends State<ProfileSettingsPage> {
     );
   }
 
-  void _editField(String field, String value) {
-    showDialog(
-      context: context,
-      builder: (context) {
-        final TextEditingController controller = TextEditingController(text: value);
-        return AlertDialog(
-          title: Text('Edit ${field.replaceAll('_', ' ').capitalize()}'),
-          content: TextField(
-            controller: controller,
-            decoration: InputDecoration(
-              hintText: 'Enter ${field.replaceAll('_', ' ')}',
-              border: OutlineInputBorder(
-                borderRadius: BorderRadius.circular(12),
+  Widget _buildLoggedInView(UserProfile profile) {
+    final avatarImage = _resolveAvatar(profile);
+
+    return RefreshIndicator(
+      onRefresh: _refreshProfile,
+      child: SingleChildScrollView(
+        physics: const AlwaysScrollableScrollPhysics(),
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Center(
+              child: Column(
+                children: [
+                  GestureDetector(
+                    onTap: _isLoading ? null : () => _pickImage(profile),
+                    child: Stack(
+                      children: [
+                        CircleAvatar(
+                          radius: 60,
+                          backgroundColor: Colors.grey[200],
+                          backgroundImage: avatarImage,
+                          child: avatarImage == null
+                              ? const Icon(Icons.person, size: 60, color: Colors.grey)
+                              : null,
+                        ),
+                        Positioned(
+                          bottom: 0,
+                          right: 0,
+                          child: Container(
+                            padding: const EdgeInsets.all(4),
+                            decoration: const BoxDecoration(
+                              color: Color(0xFF8B5CF6),
+                              shape: BoxShape.circle,
+                            ),
+                            child: const Icon(Icons.camera_alt, color: Colors.white, size: 20),
+                          ),
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                  Text(
+                    profile.fullName ?? profile.username ?? 'Username',
+                    style: const TextStyle(
+                      fontSize: 24,
+                      fontWeight: FontWeight.bold,
+                    ),
+                  ),
+                  Text(
+                    profile.email ?? 'Email',
+                    style: TextStyle(
+                      fontSize: 16,
+                      color: Colors.grey[600],
+                    ),
+                  ),
+                ],
               ),
             ),
-            maxLines: field == 'bio' ? 3 : 1,
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Cancel'),
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                if (controller.text.isNotEmpty) {
-                  Navigator.pop(context);
-                  setState(() => _isLoading = true);
-                  
-                  try {
-                    // Update the profile
-                    if (field == 'username') {
-                      await _localDBService.updateUserProfile(
-                        userId: _localDBService.currentUser!.id,
-                        username: controller.text,
-                      );
-                    } else if (field == 'full_name') {
-                      await _localDBService.updateUserProfile(
-                        userId: _localDBService.currentUser!.id,
-                        fullName: controller.text,
-                      );
-                    } else if (field == 'profession') {
-                      await _localDBService.updateUserProfile(
-                        userId: _localDBService.currentUser!.id,
-                        profession: controller.text,
-                      );
-                    } else if (field == 'bio') {
-                      await _localDBService.updateUserProfile(
-                        userId: _localDBService.currentUser!.id,
-                        bio: controller.text,
-                      );
-                    }
-                    
-                    if (!mounted) return;
-                    setState(() {
-                      if (field == 'username') {
-                        _username = controller.text;
-                      } else if (field == 'full_name') {
-                        _fullName = controller.text;
-                      } else if (field == 'bio') {
-                        // No UI field to update
-                      } else if (field == 'profession') {
-                        _profession = controller.text;
-                      }
-                      // Reload user data to ensure all fields are updated
-                      _loadUserData();
-                      _isLoading = false;
-                    });
-                    
-                    if (!mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(
-                        content: Text('Profile updated successfully'),
-                        backgroundColor: Color(0xFF8B5CF6),
-                      ),
-                    );
-                  } catch (e) {
-                    if (!mounted) return;
-                    setState(() => _isLoading = false);
-                    if (!mounted) return;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(
-                        content: Text('Error updating profile: $e'),
-                        backgroundColor: Colors.red,
-                      ),
-                    );
-                  }
-                }
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF8B5CF6),
-                foregroundColor: Colors.white,
+            const SizedBox(height: 24),
+            _buildDeletionBanner(profile),
+            const SizedBox(height: 8),
+            _buildSectionTitle('Personal Information'),
+            const SizedBox(height: 16),
+            _buildEditableField(
+              label: 'Full Name',
+              value: profile.fullName ?? '',
+              onTap: () => _promptForValue(
+                label: 'full name',
+                initialValue: profile.fullName ?? '',
+                onSubmit: (value) => _updateProfile(fullName: value),
               ),
-              child: const Text('Save'),
             ),
+            _buildEditableField(
+              label: 'Username',
+              value: profile.username ?? '',
+              onTap: () => _promptForValue(
+                label: 'username',
+                initialValue: profile.username ?? '',
+                onSubmit: (value) => _updateProfile(username: value),
+              ),
+            ),
+            _buildEditableField(
+              label: 'Bio',
+              value: profile.bio ?? '',
+              onTap: () => _promptForValue(
+                label: 'bio',
+                initialValue: profile.bio ?? '',
+                maxLines: 3,
+                onSubmit: (value) => _updateProfile(bio: value),
+              ),
+            ),
+            _buildEditableField(
+              label: 'Date of Birth',
+              value: _formatDate(profile.dateOfBirth),
+              onTap: () => _selectDate(profile),
+            ),
+            _buildEditableField(
+              label: 'Profession',
+              value: profile.profession ?? '',
+              onTap: () => _promptForValue(
+                label: 'profession',
+                initialValue: profile.profession ?? '',
+                onSubmit: (value) => _updateProfile(profession: value),
+              ),
+            ),
+            const SizedBox(height: 24),
+            _buildSectionTitle('Account Settings'),
+            const SizedBox(height: 16),
+            _buildSettingsItem(
+              icon: Icons.lock_outline,
+              title: 'Change Password',
+              onTap: _isLoading ? null : _changePassword,
+            ),
+            _buildSettingsItem(
+              icon: Icons.delete_outline,
+              title: profile.hasPendingDeletion ? 'Deletion scheduled' : 'Delete Account',
+              onTap: _isLoading
+                  ? null
+                  : (profile.hasPendingDeletion ? _cancelDeletion : _requestDeletion),
+              isDestructive: true,
+            ),
+            const SizedBox(height: 24),
+            Center(
+              child: ElevatedButton.icon(
+                onPressed: _isLoading ? null : _signOut,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: const Color(0xFF8B5CF6),
+                  foregroundColor: Colors.white,
+                  padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 12),
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(12),
+                  ),
+                ),
+                icon: const Icon(Icons.logout, size: 20),
+                label: const Text('Logout'),
+              ),
+            ),
+            const SizedBox(height: 32),
           ],
-        );
-      },
-    );
-  }
-
-  void _selectDate(BuildContext context) async {
-    final DateTime? picked = await showDatePicker(
-      context: context,
-      initialDate: _dateOfBirth ?? DateTime(2000),
-      firstDate: DateTime(1900),
-      lastDate: DateTime.now(),
-      builder: (context, child) {
-        return Theme(
-          data: ThemeData.light().copyWith(
-            colorScheme: const ColorScheme.light(
-              primary: Color(0xFF8B5CF6),
-            ),
-          ),
-          child: child!,
-        );
-      },
-    );
-    
-    if (picked != null && picked != _dateOfBirth) {
-      setState(() => _isLoading = true);
-      
-      try {
-        await _localDBService.updateUserProfile(
-          userId: _localDBService.currentUser!.id,
-          dateOfBirth: picked,
-        );
-        
-        if (!mounted) return;
-        setState(() {
-          _dateOfBirth = picked;
-        });
-
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Date of birth updated successfully'),
-            backgroundColor: Color(0xFF8B5CF6),
-          ),
-        );
-      } catch (e) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error updating date of birth: ${e.toString()}')),
-        );
-      } finally {
-        setState(() {
-          _isLoading = false;
-        });
-      }
-    }
-  }
-
-  void _changePassword() {
-    showDialog(
-      context: context,
-      builder: (context) {
-        final TextEditingController currentPasswordController = TextEditingController();
-        final TextEditingController newPasswordController = TextEditingController();
-        final TextEditingController confirmPasswordController = TextEditingController();
-        
-        return AlertDialog(
-          title: const Text('Change Password'),
-          content: Column(
-            mainAxisSize: MainAxisSize.min,
-            children: [
-              TextField(
-                controller: currentPasswordController,
-                obscureText: true,
-                decoration: InputDecoration(
-                  hintText: 'Current Password',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: newPasswordController,
-                obscureText: true,
-                decoration: InputDecoration(
-                  hintText: 'New Password',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-              ),
-              const SizedBox(height: 16),
-              TextField(
-                controller: confirmPasswordController,
-                obscureText: true,
-                decoration: InputDecoration(
-                  hintText: 'Confirm New Password',
-                  border: OutlineInputBorder(
-                    borderRadius: BorderRadius.circular(12),
-                  ),
-                ),
-              ),
-            ],
-          ),
-          actions: [
-            TextButton(
-              onPressed: () => Navigator.pop(context),
-              child: const Text('Cancel'),
-            ),
-            ElevatedButton(
-              onPressed: () async {
-                if (newPasswordController.text.isEmpty || 
-                    currentPasswordController.text.isEmpty ||
-                    confirmPasswordController.text.isEmpty) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Please fill all fields'),
-                      backgroundColor: Colors.red,
-                    ),
-                  );
-                  return;
-                }
-                
-                if (newPasswordController.text != confirmPasswordController.text) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('New passwords do not match'),
-                      backgroundColor: Colors.red,
-                    ),
-                  );
-                  return;
-                }
-                
-                Navigator.pop(context);
-                setState(() => _isLoading = true);
-                
-                try {
-                  // Change password using the local DB service
-                  await _localDBService.changePassword(
-                    userId: _localDBService.currentUser!.id,
-                    currentPassword: currentPasswordController.text,
-                    newPassword: newPasswordController.text,
-                  );
-                  
-                  Navigator.of(context).pop();
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(
-                      content: Text('Password changed successfully'),
-                      backgroundColor: Color(0xFF8B5CF6),
-                    ),
-                  );
-                } catch (e) {
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(
-                      content: Text('Error changing password: ${e.toString()}'),
-                      backgroundColor: Colors.red,
-                    ),
-                  );
-                }
-              },
-              style: ElevatedButton.styleFrom(
-                backgroundColor: const Color(0xFF8B5CF6),
-                foregroundColor: Colors.white,
-              ),
-              child: const Text('Change Password'),
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  void _deleteAccount() {
-    showDialog(
-      context: context,
-      builder: (context) => AlertDialog(
-        title: const Text('Delete Account'),
-        content: const Text(
-          'Are you sure you want to delete your account? This action cannot be undone.',
-          style: TextStyle(fontSize: 16),
         ),
-        actions: [
-          TextButton(
-            onPressed: () => Navigator.pop(context),
-            child: const Text('Cancel'),
-          ),
-          ElevatedButton(
-            onPressed: () async {
-              Navigator.pop(context);
-              setState(() => _isLoading = true);
-              
-              try {
-                // Delete user account from local database
-                await _localDBService.deleteUser(_localDBService.currentUser!.id);
-                
-                setState(() {
-                  _isLoggedIn = false;
-                  _email = null;
-                  _username = null;
-                  _profileImageFile = null;
-                  _profileImageUrl = null;
-                  _fullName = null;
-                  _dateOfBirth = null;
-                  _profession = null;
-                });
-                
-                Navigator.of(context).pop();
-                ScaffoldMessenger.of(context).showSnackBar(
-                  const SnackBar(content: Text('Account deleted successfully')),
-                );
-              } catch (e) {
-                setState(() => _isLoading = false);
-                if (!mounted) return;
-                ScaffoldMessenger.of(context).showSnackBar(
-                  SnackBar(
-                    content: Text('Error deleting account: $e'),
-                    backgroundColor: Colors.red,
-                  ),
-                );
-              }
-            },
-            style: ElevatedButton.styleFrom(
-              backgroundColor: Colors.red,
-              foregroundColor: Colors.white,
-            ),
-            child: const Text('Delete'),
-          ),
-        ],
       ),
     );
   }
 
-  String _formatDate(String date) {
-    try {
-      final DateTime dateTime = DateTime.parse(date);
-      return '${dateTime.day}/${dateTime.month}/${dateTime.year}';
-    } catch (e) {
-      return 'Invalid date';
-    }
-  }
-
-  void _logout() {
-    _signOut();
+  Widget _buildSectionTitle(String title) {
+    return Text(
+      title,
+      style: const TextStyle(
+        fontSize: 18,
+        fontWeight: FontWeight.bold,
+        color: Color(0xFF8B5CF6),
+      ),
+    );
   }
 
   Widget _buildLoginView() {
     return AuthPage(
-      onLoginSuccess: _handleLoginSuccess,
       showAppBar: false,
+      allowSkip: false,
+      onAuthenticated: (ctx) => _refreshProfile(),
     );
   }
 
   @override
   Widget build(BuildContext context) {
+    final authService = context.watch<AuthService>();
+    final profile = authService.currentProfile;
+
     return Scaffold(
       backgroundColor: Colors.grey[50],
       appBar: AppBar(
@@ -859,8 +658,8 @@ class _ProfileSettingsPageState extends State<ProfileSettingsPage> {
       ),
       body: _isLoading
           ? const Center(child: CircularProgressIndicator(color: Color(0xFF8B5CF6)))
-          : _isLoggedIn
-              ? _buildLoggedInView()
+          : authService.isAuthenticated && profile != null
+              ? _buildLoggedInView(profile)
               : _buildLoginView(),
     );
   }

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -63,6 +63,12 @@ class _SettingsPageState extends State<SettingsPage> {
             iconColor: Colors.blue,
             title: 'Profile Settings',
             subtitle: 'Manage your account and preferences',
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const ProfileSettingsPage()),
+              );
+            },
           ),
           _buildSettingsItem(
             icon: Icons.notifications_outlined,

--- a/lib/services/app_config.dart
+++ b/lib/services/app_config.dart
@@ -1,0 +1,18 @@
+class AppConfig {
+  const AppConfig._();
+
+  /// Base URL for the Supabase project. Provide this value at build time using
+  /// `--dart-define SUPABASE_URL=...` or replace the default with your
+  /// project's URL.
+  static const String supabaseUrl = String.fromEnvironment(
+    'SUPABASE_URL',
+    defaultValue: '',
+  );
+
+  /// Anonymous key for the Supabase project. Provide this value at build time
+  /// using `--dart-define SUPABASE_ANON_KEY=...`.
+  static const String supabaseAnonKey = String.fromEnvironment(
+    'SUPABASE_ANON_KEY',
+    defaultValue: '',
+  );
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -1,141 +1,614 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'local_db_service.dart';
-import '../component/models.dart';
+import 'dart:async';
 
-class AuthService {
-  final LocalDBService _localDBService = LocalDBService();
-  final _secureStorage = const FlutterSecureStorage();
+import 'package:flutter/foundation.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
-  User? get currentUser => _localDBService.currentUser;
-  bool get isLoggedIn => currentUser != null;
+import 'supabase_service.dart';
 
-  // Check if an email exists in the local database
-  Future<bool> checkEmailExists(String email) async {
-    try {
-      final user = await _localDBService.getUserByEmail(email);
-      return user != null;
-    } catch (e) {
-      print('Error checking email: $e');
-      return false;
-    }
-  }
+enum AuthStatus {
+  unknown,
+  unavailable,
+  unauthenticated,
+  authenticating,
+  authenticated,
+  error,
+}
 
-  Future<User> signUp({
-    required String email,
-    required String password,
-    String? fullName,
-    String? username,
-  }) async {
-    try {
-      final exists = await checkEmailExists(email);
-      if (exists) {
-        throw Exception('Email is already in use.');
+class AuthResult {
+  const AuthResult({
+    required this.success,
+    this.message,
+    this.requiresEmailConfirmation = false,
+    this.profile,
+  });
+
+  final bool success;
+  final String? message;
+  final bool requiresEmailConfirmation;
+  final UserProfile? profile;
+}
+
+class UserProfile {
+  const UserProfile({
+    required this.id,
+    this.email,
+    this.fullName,
+    this.username,
+    this.bio,
+    this.dateOfBirth,
+    this.profession,
+    this.avatarUrl,
+    this.surveyCompleted = false,
+    this.createdAt,
+    this.updatedAt,
+    this.deletionRequestedAt,
+    this.deletionScheduledFor,
+    this.deletionStatus,
+  });
+
+  factory UserProfile.fromMap(Map<String, dynamic> map) {
+    DateTime? _parseDate(dynamic value) {
+      if (value == null) return null;
+      if (value is DateTime) return value;
+      if (value is String && value.isNotEmpty) {
+        return DateTime.tryParse(value)?.toUtc();
       }
-      
-      final user = await _localDBService.register(
-        email: email,
-        password: password,
-        fullName: fullName,
-        username: username,
-      );
-      
-      await _storeSession(user.id);
-      return user;
-    } catch (e) {
-      print('Signup error: $e');
-      rethrow;
-    }
-  }
-
-  Future<User> signIn({
-    required String email,
-    required String password,
-  }) async {
-    try {
-      final user = await _localDBService.login(
-        email: email,
-        password: password,
-      );
-      await _storeSession(user.id);
-      return user;
-    } catch (e) {
-      rethrow;
-    }
-  }
-
-  Future<void> signOut() async {
-    await _localDBService.logout();
-    await _clearSession();
-  }
-
-  Future<void> _storeSession(String userId) async {
-    await _secureStorage.write(key: 'user_id', value: userId);
-  }
-
-  Future<void> _clearSession() async {
-    await _secureStorage.delete(key: 'user_id');
-  }
-
-  Future<void> restoreSession() async {
-    final userId = await _secureStorage.read(key: 'user_id');
-    if (userId != null) {
-      try {
-        await _localDBService.loginWithId(userId);
-      } catch (e) {
-        await _clearSession();
-      }
-    }
-  }
-
-  Future<void> resetPassword(String email) async {
-    try {
-      // Generate a temporary password
-      const tempPassword = 'Reset123!';
-      await _localDBService.resetPassword(
-        email: email,
-        newPassword: tempPassword,
-      );
-      // In a real app, you would send this password via email
-    } catch (e) {
-      print('Error resetting password: $e');
-      rethrow;
-    }
-  }
-
-  Future<User?> getUserData() async {
-    try {
-      if (currentUser == null) return null;
-      return currentUser;
-    } catch (e) {
-      print('Error getting user data: $e');
       return null;
     }
+
+    return UserProfile(
+      id: map['id'] as String,
+      email: map['email'] as String?,
+      fullName: map['full_name'] as String?,
+      username: map['username'] as String?,
+      bio: map['bio'] as String?,
+      dateOfBirth: _parseDate(map['date_of_birth']),
+      profession: map['profession'] as String?,
+      avatarUrl: map['avatar_url'] as String?,
+      surveyCompleted: (map['survey_completed'] as bool?) ??
+          (map['survey_completed'] is int
+              ? (map['survey_completed'] as int) == 1
+              : false),
+      createdAt: _parseDate(map['created_at']),
+      updatedAt: _parseDate(map['updated_at']),
+      deletionRequestedAt: _parseDate(map['deletion_requested_at']),
+      deletionScheduledFor: _parseDate(map['deletion_scheduled_for']),
+      deletionStatus: map['deletion_status'] as String?,
+    );
   }
 
-  Future<void> updateUserProfile({
-    required String userId,
+  Map<String, dynamic> toInsertMap() {
+    return {
+      'id': id,
+      if (fullName != null) 'full_name': fullName,
+      if (username != null) 'username': username,
+      if (bio != null) 'bio': bio,
+      if (dateOfBirth != null) 'date_of_birth': dateOfBirth!.toIso8601String(),
+      if (profession != null) 'profession': profession,
+      if (avatarUrl != null) 'avatar_url': avatarUrl,
+      'survey_completed': surveyCompleted,
+      if (createdAt != null) 'created_at': createdAt!.toIso8601String(),
+      if (updatedAt != null) 'updated_at': updatedAt!.toIso8601String(),
+      if (deletionRequestedAt != null)
+        'deletion_requested_at': deletionRequestedAt!.toIso8601String(),
+      if (deletionScheduledFor != null)
+        'deletion_scheduled_for': deletionScheduledFor!.toIso8601String(),
+      if (deletionStatus != null) 'deletion_status': deletionStatus,
+    };
+  }
+
+  UserProfile copyWith({
+    String? id,
+    String? email,
     String? fullName,
     String? username,
     String? bio,
     DateTime? dateOfBirth,
     String? profession,
-    String? heardFrom,
+    String? avatarUrl,
+    bool? surveyCompleted,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+    DateTime? deletionRequestedAt,
+    DateTime? deletionScheduledFor,
+    String? deletionStatus,
+  }) {
+    return UserProfile(
+      id: id ?? this.id,
+      email: email ?? this.email,
+      fullName: fullName ?? this.fullName,
+      username: username ?? this.username,
+      bio: bio ?? this.bio,
+      dateOfBirth: dateOfBirth ?? this.dateOfBirth,
+      profession: profession ?? this.profession,
+      avatarUrl: avatarUrl ?? this.avatarUrl,
+      surveyCompleted: surveyCompleted ?? this.surveyCompleted,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+      deletionRequestedAt: deletionRequestedAt ?? this.deletionRequestedAt,
+      deletionScheduledFor: deletionScheduledFor ?? this.deletionScheduledFor,
+      deletionStatus: deletionStatus ?? this.deletionStatus,
+    );
+  }
+
+  bool get hasPendingDeletion {
+    if (deletionStatus != 'pending') {
+      return false;
+    }
+    final scheduled = deletionScheduledFor;
+    if (scheduled == null) {
+      return false;
+    }
+    return scheduled.isAfter(DateTime.now().toUtc());
+  }
+
+  Duration? get timeUntilDeletion {
+    if (!hasPendingDeletion) {
+      return null;
+    }
+    return deletionScheduledFor!.difference(DateTime.now().toUtc());
+  }
+}
+
+class AuthService extends ChangeNotifier {
+  AuthService._internal();
+
+  static final AuthService _instance = AuthService._internal();
+
+  factory AuthService() => _instance;
+
+  static const _skipPreferenceKey = 'auth.skip_flow';
+
+  final SupabaseService _supabaseService = SupabaseService();
+
+  UserProfile? _currentProfile;
+  AuthStatus _status = AuthStatus.unknown;
+  String? _errorMessage;
+  bool _hasSkippedAuth = false;
+  StreamSubscription<AuthState>? _authSubscription;
+  Completer<void>? _initializationCompleter;
+
+  UserProfile? get currentProfile => _currentProfile;
+  AuthStatus get status => _status;
+  String? get errorMessage => _errorMessage;
+  bool get hasSkippedAuth => _hasSkippedAuth;
+  bool get isAuthenticated => _status == AuthStatus.authenticated;
+  bool get canAttemptAuthentication => _supabaseService.isInitialized;
+
+  Future<void> ready() async {
+    if (_initializationCompleter != null) {
+      await _initializationCompleter!.future;
+    }
+  }
+
+  Future<void> initialize() async {
+    if (_initializationCompleter != null) {
+      return _initializationCompleter!.future;
+    }
+
+    _initializationCompleter = Completer<void>();
+
+    final prefs = await SharedPreferences.getInstance();
+    _hasSkippedAuth = prefs.getBool(_skipPreferenceKey) ?? false;
+
+    if (!_supabaseService.isInitialized) {
+      _status = AuthStatus.unavailable;
+      _errorMessage = _supabaseService.initializationError ??
+          'Authentication is not available. Configure Supabase credentials to enable sign in.';
+      _initializationCompleter!.complete();
+      notifyListeners();
+      return;
+    }
+
+    try {
+      _errorMessage = null;
+      final session = _supabaseService.client.auth.currentSession;
+      if (session != null) {
+        await _handleSignedIn(session, notifyAfter: false);
+      } else {
+        _status = AuthStatus.unauthenticated;
+      }
+
+      _authSubscription =
+          _supabaseService.client.auth.onAuthStateChange.listen((data) {
+        final event = data.event;
+        final session = data.session;
+
+        if (event == AuthChangeEvent.signedIn && session != null) {
+          _handleSignedIn(session);
+        } else if (event == AuthChangeEvent.signedOut) {
+          _currentProfile = null;
+          _status = AuthStatus.unauthenticated;
+          notifyListeners();
+        } else if (event == AuthChangeEvent.userUpdated && session != null) {
+          _handleSignedIn(session, notifyAfter: true);
+        }
+      });
+
+      _initializationCompleter!.complete();
+      notifyListeners();
+    } catch (error) {
+      _status = AuthStatus.error;
+      _errorMessage = error.toString();
+      _initializationCompleter!.complete();
+      notifyListeners();
+    }
+  }
+
+  Future<void> _handleSignedIn(Session session, {bool notifyAfter = true}) async {
+    _status = AuthStatus.authenticated;
+    _errorMessage = null;
+
+    try {
+      final profile = await _ensureProfile(session.user);
+      _currentProfile = profile;
+
+      if (profile.hasPendingDeletion) {
+        await cancelAccountDeletion();
+      } else {
+        notifyListeners();
+      }
+    } catch (error) {
+      _status = AuthStatus.error;
+      _errorMessage = error.toString();
+      if (notifyAfter) {
+        notifyListeners();
+      }
+    }
+    if (notifyAfter) {
+      notifyListeners();
+    }
+  }
+
+  Future<UserProfile> _ensureProfile(User supabaseUser) async {
+    final profileData = await _supabaseService.client
+        .from('profiles')
+        .select()
+        .eq('id', supabaseUser.id)
+        .maybeSingle();
+
+    if (profileData != null) {
+      return UserProfile.fromMap(profileData as Map<String, dynamic>);
+    }
+
+    final now = DateTime.now().toUtc();
+    final profile = UserProfile(
+      id: supabaseUser.id,
+      email: supabaseUser.email,
+      surveyCompleted: false,
+      createdAt: now,
+      updatedAt: now,
+    );
+
+    await _supabaseService.client.from('profiles').insert(profile.toInsertMap());
+    return profile;
+  }
+
+  Future<AuthResult> signUp({
+    required String email,
+    required String password,
+  }) async {
+    if (!_supabaseService.isInitialized) {
+      return const AuthResult(
+        success: false,
+        message: 'Authentication is not available. Configure Supabase credentials to enable sign up.',
+      );
+    }
+
+    _status = AuthStatus.authenticating;
+    notifyListeners();
+
+    try {
+      final response = await _supabaseService.client.auth.signUp(
+        email: email,
+        password: password,
+      );
+
+      final user = response.user;
+      final session = response.session;
+
+      if (user == null) {
+        _status = AuthStatus.unauthenticated;
+        _errorMessage = 'Unable to create the account. Please try again.';
+        notifyListeners();
+        return const AuthResult(
+          success: false,
+          message: 'Unable to create the account. Please try again.',
+        );
+      }
+
+      if (session == null) {
+        _status = AuthStatus.unauthenticated;
+        _currentProfile = null;
+        _errorMessage = null;
+        notifyListeners();
+        return AuthResult(
+          success: true,
+          requiresEmailConfirmation: true,
+          message:
+              'A confirmation link has been sent to $email. Please verify your email to continue.',
+        );
+      }
+
+      final profile = await _ensureProfile(user);
+      _currentProfile = profile;
+      _status = AuthStatus.authenticated;
+      _errorMessage = null;
+      notifyListeners();
+      return AuthResult(
+        success: true,
+        profile: profile,
+      );
+    } on AuthException catch (error) {
+      _status = AuthStatus.unauthenticated;
+      _errorMessage = error.message;
+      notifyListeners();
+      return AuthResult(success: false, message: error.message);
+    } catch (error) {
+      _status = AuthStatus.error;
+      _errorMessage = error.toString();
+      notifyListeners();
+      return AuthResult(success: false, message: error.toString());
+    }
+  }
+
+  Future<AuthResult> signIn({
+    required String email,
+    required String password,
+  }) async {
+    if (!_supabaseService.isInitialized) {
+      return const AuthResult(
+        success: false,
+        message: 'Authentication is not available. Configure Supabase credentials to enable sign in.',
+      );
+    }
+
+    _status = AuthStatus.authenticating;
+    notifyListeners();
+
+    try {
+      final response = await _supabaseService.client.auth.signInWithPassword(
+        email: email,
+        password: password,
+      );
+
+      final session = response.session;
+      final user = response.user;
+      if (session != null && user != null) {
+        final profile = await _ensureProfile(user);
+        _currentProfile = profile;
+        _status = AuthStatus.authenticated;
+        _errorMessage = null;
+        notifyListeners();
+        return AuthResult(success: true, profile: profile);
+      }
+
+      _status = AuthStatus.unauthenticated;
+      notifyListeners();
+      return const AuthResult(
+        success: false,
+        message: 'Unable to sign in. Please try again.',
+      );
+    } on AuthException catch (error) {
+      _status = AuthStatus.unauthenticated;
+      _errorMessage = error.message;
+      notifyListeners();
+      return AuthResult(success: false, message: error.message);
+    } catch (error) {
+      _status = AuthStatus.error;
+      _errorMessage = error.toString();
+      notifyListeners();
+      return AuthResult(success: false, message: error.toString());
+    }
+  }
+
+  Future<void> signOut() async {
+    if (!_supabaseService.isInitialized) {
+      return;
+    }
+
+    await _supabaseService.client.auth.signOut();
+    _currentProfile = null;
+    _status = AuthStatus.unauthenticated;
+    notifyListeners();
+  }
+
+  Future<void> refreshProfile() async {
+    if (!_supabaseService.isInitialized || _currentProfile == null) {
+      return;
+    }
+
+    try {
+      final data = await _supabaseService.client
+          .from('profiles')
+          .select()
+          .eq('id', _currentProfile!.id)
+          .maybeSingle();
+
+      if (data != null) {
+        _currentProfile = UserProfile.fromMap(data as Map<String, dynamic>);
+        notifyListeners();
+      }
+    } catch (error) {
+      if (kDebugMode) {
+        debugPrint('Failed to refresh profile: $error');
+      }
+    }
+  }
+
+  Future<AuthResult> resetPassword(String email) async {
+    if (!_supabaseService.isInitialized) {
+      return const AuthResult(
+        success: false,
+        message: 'Reset password is unavailable without Supabase configuration.',
+      );
+    }
+
+    try {
+      await _supabaseService.client.auth.resetPasswordForEmail(email);
+      return const AuthResult(
+        success: true,
+        message: 'Password reset instructions have been sent to your email.',
+      );
+    } on AuthException catch (error) {
+      return AuthResult(success: false, message: error.message);
+    } catch (error) {
+      return AuthResult(success: false, message: error.toString());
+    }
+  }
+
+  Future<void> updateProfile({
+    String? fullName,
+    String? username,
+    String? bio,
+    DateTime? dateOfBirth,
+    String? profession,
     String? avatarUrl,
     bool? surveyCompleted,
   }) async {
-    try {
-      await _localDBService.updateUserProfile(
-        userId: userId,
-        fullName: fullName,
-        username: username,
-        bio: bio,
-        dateOfBirth: dateOfBirth,
-        profession: profession,
-        avatarUrl: avatarUrl,
-      );
-    } catch (e) {
-      print('Error updating profile: $e');
-      rethrow;
+    if (!_supabaseService.isInitialized || _currentProfile == null) {
+      return;
     }
+
+    final Map<String, dynamic> updates = {
+      'updated_at': DateTime.now().toUtc().toIso8601String(),
+    };
+
+    if (fullName != null) updates['full_name'] = fullName;
+    if (username != null) updates['username'] = username;
+    if (bio != null) updates['bio'] = bio;
+    if (dateOfBirth != null) {
+      updates['date_of_birth'] = dateOfBirth.toIso8601String();
+    }
+    if (profession != null) updates['profession'] = profession;
+    if (avatarUrl != null) updates['avatar_url'] = avatarUrl;
+    if (surveyCompleted != null) updates['survey_completed'] = surveyCompleted;
+
+    if (updates.length <= 1) {
+      return;
+    }
+
+    await _supabaseService.client
+        .from('profiles')
+        .update(updates)
+        .eq('id', _currentProfile!.id);
+
+    _currentProfile = _currentProfile!.copyWith(
+      fullName: fullName ?? _currentProfile!.fullName,
+      username: username ?? _currentProfile!.username,
+      bio: bio ?? _currentProfile!.bio,
+      dateOfBirth: dateOfBirth ?? _currentProfile!.dateOfBirth,
+      profession: profession ?? _currentProfile!.profession,
+      avatarUrl: avatarUrl ?? _currentProfile!.avatarUrl,
+      surveyCompleted: surveyCompleted ?? _currentProfile!.surveyCompleted,
+      updatedAt: DateTime.now().toUtc(),
+    );
+
+    notifyListeners();
+  }
+
+  Future<AuthResult> changePassword({
+    required String currentPassword,
+    required String newPassword,
+  }) async {
+    if (!_supabaseService.isInitialized || _currentProfile == null) {
+      return const AuthResult(
+        success: false,
+        message: 'Password change is unavailable. Please sign in first.',
+      );
+    }
+
+    final email = _currentProfile!.email;
+    if (email == null) {
+      return const AuthResult(
+        success: false,
+        message: 'Unable to verify your email address. Please sign out and sign in again.',
+      );
+    }
+
+    try {
+      await _supabaseService.client.auth.signInWithPassword(
+        email: email,
+        password: currentPassword,
+      );
+
+      await _supabaseService.client.auth.updateUser(
+        UserAttributes(password: newPassword),
+      );
+
+      return const AuthResult(success: true, message: 'Password updated successfully.');
+    } on AuthException catch (error) {
+      return AuthResult(success: false, message: error.message);
+    } catch (error) {
+      return AuthResult(success: false, message: error.toString());
+    }
+  }
+
+  Future<void> requestAccountDeletion() async {
+    if (!_supabaseService.isInitialized || _currentProfile == null) {
+      return;
+    }
+
+    final now = DateTime.now().toUtc();
+    final scheduled = now.add(const Duration(days: 30));
+
+    await _supabaseService.client.from('profiles').update({
+      'deletion_requested_at': now.toIso8601String(),
+      'deletion_scheduled_for': scheduled.toIso8601String(),
+      'deletion_status': 'pending',
+      'updated_at': now.toIso8601String(),
+    }).eq('id', _currentProfile!.id);
+
+    _currentProfile = _currentProfile!.copyWith(
+      deletionRequestedAt: now,
+      deletionScheduledFor: scheduled,
+      deletionStatus: 'pending',
+      updatedAt: now,
+    );
+
+    notifyListeners();
+  }
+
+  Future<void> cancelAccountDeletion() async {
+    if (!_supabaseService.isInitialized || _currentProfile == null) {
+      return;
+    }
+
+    await _supabaseService.client.from('profiles').update({
+      'deletion_requested_at': null,
+      'deletion_scheduled_for': null,
+      'deletion_status': null,
+      'updated_at': DateTime.now().toUtc().toIso8601String(),
+    }).eq('id', _currentProfile!.id);
+
+    _currentProfile = _currentProfile!.copyWith(
+      deletionRequestedAt: null,
+      deletionScheduledFor: null,
+      deletionStatus: null,
+      updatedAt: DateTime.now().toUtc(),
+    );
+
+    notifyListeners();
+  }
+
+  Future<void> markAuthSkipped() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_skipPreferenceKey, true);
+    _hasSkippedAuth = true;
+    notifyListeners();
+  }
+
+  Future<void> clearAuthSkip() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.remove(_skipPreferenceKey);
+    _hasSkippedAuth = false;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _authSubscription?.cancel();
+    super.dispose();
   }
 }

--- a/lib/services/supabase_service.dart
+++ b/lib/services/supabase_service.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/foundation.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+import 'app_config.dart';
+
+class SupabaseService {
+  SupabaseService._internal();
+
+  static final SupabaseService _instance = SupabaseService._internal();
+
+  factory SupabaseService() => _instance;
+
+  SupabaseClient? _client;
+  bool _isInitialized = false;
+  String? _initializationError;
+
+  bool get isConfigured =>
+      AppConfig.supabaseUrl.isNotEmpty && AppConfig.supabaseAnonKey.isNotEmpty;
+
+  bool get isInitialized => _isInitialized;
+
+  String? get initializationError => _initializationError;
+
+  SupabaseClient get client {
+    final supabaseClient = _client;
+    if (supabaseClient == null) {
+      throw StateError(
+        'Supabase has not been initialized. Call initialize() before accessing the client.',
+      );
+    }
+    return supabaseClient;
+  }
+
+  Future<bool> initialize() async {
+    if (_isInitialized) {
+      return true;
+    }
+
+    if (!isConfigured) {
+      _initializationError =
+          'Supabase credentials are missing. Provide SUPABASE_URL and SUPABASE_ANON_KEY via --dart-define.';
+      if (kDebugMode) {
+        debugPrint(_initializationError);
+      }
+      return false;
+    }
+
+    try {
+      await Supabase.initialize(
+        url: AppConfig.supabaseUrl,
+        anonKey: AppConfig.supabaseAnonKey,
+        debug: kDebugMode,
+      );
+      _client = Supabase.instance.client;
+      _isInitialized = true;
+      _initializationError = null;
+      return true;
+    } catch (error, stackTrace) {
+      _initializationError = error.toString();
+      if (kDebugMode) {
+        debugPrint('Supabase initialization failed: $error');
+        debugPrint(stackTrace.toString());
+      }
+      return false;
+    }
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,13 +34,12 @@ dependencies:
   system_info2: ^4.0.0
   url_launcher: ^6.2.4
   permission_handler: ^11.0.1
-  #supabase_flutter: ^1.10.25
+  supabase_flutter: ^2.8.4
   flutter_secure_storage: ^9.0.0
   timeago: ^3.6.0
   ollama_dart: ^0.0.2
   flutter_bloc: ^8.1.4
   equatable: ^2.0.5
-  # supabase_flutter: ^2.8.4
   sign_in_with_apple: ^6.1.4
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.


### PR DESCRIPTION
## Summary
- surface Supabase initialization errors so the auth UI explains when credentials are missing
- guard the email sign-up path when Supabase requires email confirmation instead of trying to insert a profile without a session
- clear stale authentication error messages after successful sign-in or sign-up transitions

## Testing
- Not run (Flutter SDK is unavailable in the container)

------
https://chatgpt.com/codex/tasks/task_e_68d3abf0b874832daa0dd90aca504003