### PR TITLE
Refine model management for remote storage

### DIFF
--- a/lib/component/model_list_item.dart
+++ b/lib/component/model_list_item.dart
@@ -131,6 +131,10 @@ class ModelListItem extends StatelessWidget {
         iconData = Icons.psychology;
         iconColor = Colors.purple;
         break;
+      case ModelProvider.openRouter:
+        iconData = Icons.route;
+        iconColor = Colors.deepPurple;
+        break;
       case ModelProvider.lmStudio:
         iconData = Icons.science;
         iconColor = Colors.blue;

--- a/lib/component/model_selector.dart
+++ b/lib/component/model_selector.dart
@@ -543,6 +543,10 @@ class _ModelSelectorState extends State<ModelSelector> {
         iconData = Icons.psychology;
         iconColor = Colors.purple;
         break;
+      case ModelProvider.openRouter:
+        iconData = Icons.route;
+        iconColor = Colors.deepPurple;
+        break;
       case ModelProvider.lmStudio:
         iconData = Icons.science;
         iconColor = Colors.orange;

--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -381,6 +381,7 @@ class ModelConfig {
   double? presencePenalty;
   Map<String, dynamic>? additionalParams;
   Map<String, dynamic>? metadata;
+  bool isDefault;
   bool isActive;
   DateTime createdAt;
   DateTime updatedAt;
@@ -401,6 +402,7 @@ class ModelConfig {
     this.presencePenalty = 0.0,
     this.additionalParams,
     this.metadata,
+    this.isDefault = false,
     this.isActive = true,
     required this.createdAt,
     required this.updatedAt,
@@ -423,6 +425,7 @@ class ModelConfig {
       'presencePenalty': presencePenalty,
       'additionalParams': additionalParams,
       'metadata': metadata,
+      'isDefault': isDefault,
       'isActive': isActive,
       'createdAt': createdAt.millisecondsSinceEpoch,
       'updatedAt': updatedAt.millisecondsSinceEpoch,
@@ -470,6 +473,7 @@ class ModelConfig {
       metadata: json['metadata'] != null
           ? Map<String, dynamic>.from(json['metadata'])
           : null,
+      isDefault: json['isDefault'] ?? json['is_default'] ?? false,
       isActive: json['isActive'] ?? true,
       createdAt: parseDate(json['createdAt']),
       updatedAt: parseDate(json['updatedAt']),
@@ -492,6 +496,7 @@ class ModelConfig {
     double? presencePenalty,
     Map<String, dynamic>? additionalParams,
     Map<String, dynamic>? metadata,
+    bool? isDefault,
     bool? isActive,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -512,6 +517,7 @@ class ModelConfig {
       presencePenalty: presencePenalty ?? this.presencePenalty,
       additionalParams: additionalParams ?? this.additionalParams,
       metadata: metadata ?? this.metadata,
+      isDefault: isDefault ?? this.isDefault,
       isActive: isActive ?? this.isActive,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/pages/model_settings_page.dart
+++ b/lib/pages/model_settings_page.dart
@@ -2,8 +2,7 @@ import 'package:flutter/material.dart';
 import '../component/models.dart';
 import '../component/model_config_dialog.dart';
 import '../component/model_list_item.dart';
-import '../services/pocket_llm_service.dart';
-import 'auth/auth_page.dart';
+import '../services/model_service.dart';
 
 class ModelSettingsPage extends StatefulWidget {
   const ModelSettingsPage({Key? key}) : super(key: key);
@@ -20,7 +19,6 @@ class _ModelSettingsPageState extends State<ModelSettingsPage> {
   bool _isLoadingModels = true;
   bool _isLoadingProviders = true;
   String? _selectedModelId;
-  final _modelService = ModelService();
 
   @override
   void initState() {
@@ -66,7 +64,14 @@ class _ModelSettingsPageState extends State<ModelSettingsPage> {
 
     try {
       final models = await _modelService.getSavedModels(refreshRemote: refreshRemote);
-      final defaultId = await _modelService.getDefaultModel();
+      String? defaultId;
+      for (final model in models) {
+        if (model.isDefault) {
+          defaultId = model.id;
+          break;
+        }
+      }
+      defaultId ??= await _modelService.getDefaultModel();
       if (!mounted) return;
       setState(() {
         _modelConfigs = models;
@@ -172,6 +177,13 @@ class _ModelSettingsPageState extends State<ModelSettingsPage> {
     if (!mounted) return;
     setState(() {
       _selectedModelId = id;
+      _modelConfigs = _modelConfigs
+          .map(
+            (model) => model.copyWith(
+              isDefault: model.id == id,
+            ),
+          )
+          .toList();
     });
   }
 

--- a/lib/services/remote_model_service.dart
+++ b/lib/services/remote_model_service.dart
@@ -166,6 +166,7 @@ class RemoteModelService {
       metadata: json['metadata'] != null
           ? Map<String, dynamic>.from(json['metadata'] as Map)
           : null,
+      isDefault: json['isDefault'] ?? json['is_default'] ?? false,
       isActive: json['isActive'] ?? true,
       createdAt: parseDate(json['createdAt']),
       updatedAt: parseDate(json['updatedAt']),

--- a/lib/services/secure_storage_service.dart
+++ b/lib/services/secure_storage_service.dart
@@ -429,7 +429,12 @@ class SecureStorageService {
         return apiKey.startsWith('sk-') && apiKey.length >= 20
             ? ApiKeyValidationResult.valid
             : ApiKeyValidationResult.invalid;
-            
+
+      case ModelProvider.openRouter:
+        return apiKey.length >= 20 && !apiKey.contains(' ')
+            ? ApiKeyValidationResult.valid
+            : ApiKeyValidationResult.invalid;
+
       case ModelProvider.pocketLLM:
         return apiKey.length >= 10
             ? ApiKeyValidationResult.valid


### PR DESCRIPTION
## Summary
- update the model settings page to rely on the shared `ModelService`, remove the duplicate field, and keep the selected model in sync with remote defaults
- replace the SharedPreferences model cache with an in-memory cache in `ModelService`, refresh data from Supabase, and add OpenRouter connectivity handling
- surface the new `isDefault` flag through `ModelConfig`, remote mapping, selectors, list items, and health checks while extending API key validation

## Testing
- Unable to run `flutter test` *(Flutter SDK is not available in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c974b60c832dba0f3c62a45b75cf