### PR TITLE
Refactor model storage to Supabase services

### DIFF
--- a/lib/component/model_list_item.dart
+++ b/lib/component/model_list_item.dart
@@ -131,6 +131,10 @@ class ModelListItem extends StatelessWidget {
         iconData = Icons.psychology;
         iconColor = Colors.purple;
         break;
+      case ModelProvider.openRouter:
+        iconData = Icons.route;
+        iconColor = Colors.deepPurple;
+        break;
       case ModelProvider.lmStudio:
         iconData = Icons.science;
         iconColor = Colors.blue;

--- a/lib/component/model_selector.dart
+++ b/lib/component/model_selector.dart
@@ -543,6 +543,10 @@ class _ModelSelectorState extends State<ModelSelector> {
         iconData = Icons.psychology;
         iconColor = Colors.purple;
         break;
+      case ModelProvider.openRouter:
+        iconData = Icons.route;
+        iconColor = Colors.deepPurple;
+        break;
       case ModelProvider.lmStudio:
         iconData = Icons.science;
         iconColor = Colors.orange;

--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -381,6 +381,7 @@ class ModelConfig {
   double? presencePenalty;
   Map<String, dynamic>? additionalParams;
   Map<String, dynamic>? metadata;
+  bool isDefault;
   bool isActive;
   DateTime createdAt;
   DateTime updatedAt;
@@ -401,6 +402,7 @@ class ModelConfig {
     this.presencePenalty = 0.0,
     this.additionalParams,
     this.metadata,
+    this.isDefault = false,
     this.isActive = true,
     required this.createdAt,
     required this.updatedAt,
@@ -423,6 +425,7 @@ class ModelConfig {
       'presencePenalty': presencePenalty,
       'additionalParams': additionalParams,
       'metadata': metadata,
+      'isDefault': isDefault,
       'isActive': isActive,
       'createdAt': createdAt.millisecondsSinceEpoch,
       'updatedAt': updatedAt.millisecondsSinceEpoch,
@@ -470,6 +473,7 @@ class ModelConfig {
       metadata: json['metadata'] != null
           ? Map<String, dynamic>.from(json['metadata'])
           : null,
+      isDefault: json['isDefault'] == true || json['is_default'] == true,
       isActive: json['isActive'] ?? true,
       createdAt: parseDate(json['createdAt']),
       updatedAt: parseDate(json['updatedAt']),
@@ -492,6 +496,7 @@ class ModelConfig {
     double? presencePenalty,
     Map<String, dynamic>? additionalParams,
     Map<String, dynamic>? metadata,
+    bool? isDefault,
     bool? isActive,
     DateTime? createdAt,
     DateTime? updatedAt,
@@ -512,6 +517,7 @@ class ModelConfig {
       presencePenalty: presencePenalty ?? this.presencePenalty,
       additionalParams: additionalParams ?? this.additionalParams,
       metadata: metadata ?? this.metadata,
+      isDefault: isDefault ?? this.isDefault,
       isActive: isActive ?? this.isActive,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,

--- a/lib/pages/model_settings_page.dart
+++ b/lib/pages/model_settings_page.dart
@@ -2,7 +2,7 @@ import 'package:flutter/material.dart';
 import '../component/models.dart';
 import '../component/model_config_dialog.dart';
 import '../component/model_list_item.dart';
-import '../services/pocket_llm_service.dart';
+import '../services/model_service.dart';
 import 'auth/auth_page.dart';
 
 class ModelSettingsPage extends StatefulWidget {
@@ -20,7 +20,6 @@ class _ModelSettingsPageState extends State<ModelSettingsPage> {
   bool _isLoadingModels = true;
   bool _isLoadingProviders = true;
   String? _selectedModelId;
-  final _modelService = ModelService();
 
   @override
   void initState() {

--- a/lib/services/remote_model_service.dart
+++ b/lib/services/remote_model_service.dart
@@ -111,6 +111,14 @@ class RemoteModelService {
     await _api.delete('models/$modelId');
   }
 
+  Future<ModelConfig> setDefaultModel(String modelId) async {
+    final data = await _api.post('models/$modelId/default');
+    if (data is Map) {
+      return _mapModel(Map<String, dynamic>.from(data));
+    }
+    throw StateError('Invalid response when setting default model');
+  }
+
   Future<List<AvailableModelOption>> getProviderModels({
     required ModelProvider provider,
     String? search,
@@ -166,6 +174,7 @@ class RemoteModelService {
       metadata: json['metadata'] != null
           ? Map<String, dynamic>.from(json['metadata'] as Map)
           : null,
+      isDefault: json['isDefault'] == true,
       isActive: json['isActive'] ?? true,
       createdAt: parseDate(json['createdAt']),
       updatedAt: parseDate(json['updatedAt']),

--- a/pocketllm-backend/src/models/models.controller.ts
+++ b/pocketllm-backend/src/models/models.controller.ts
@@ -59,5 +59,17 @@ export class ModelsController {
   ) {
     return this.modelsService.deleteModel(request.user.id, params.modelId);
   }
+
+  @Post(':modelId/default')
+  @ApiOperation({
+    summary: 'Set default model',
+    description: 'Marks the selected model as the default for the authenticated user',
+  })
+  async setDefaultModel(
+    @Param(new ZodValidationPipe(modelIdParamsSchema.params)) params: ModelIdParams,
+    @Req() request: any,
+  ) {
+    return this.modelsService.setDefaultModel(request.user.id, params.modelId);
+  }
 }
 


### PR DESCRIPTION
## Summary
- refactor the Flutter model service to rely on the remote Supabase APIs, remove SharedPreferences caching, and ensure default model handling comes from the backend
- add `isDefault` support to model configuration data structures and expose the new default setter endpoint in the NestJS backend
- update UI components to import the correct model service and handle the OpenRouter provider icons consistently

## Testing
- npm run lint *(fails: ESLint 9 requires migrating to eslint.config.js)*

------
https://chatgpt.com/codex/tasks/task_e_68d3c974b60c832dba0f3c62a45b75cf