### PR TITLE
Fix provider activation request typing

### DIFF
--- a/pocketllm-backend/src/api/v1/schemas/providers.schemas.ts
+++ b/pocketllm-backend/src/api/v1/schemas/providers.schemas.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 export const providerCodeSchema = z.enum(['openai', 'anthropic', 'ollama', 'openrouter']);
+export type ProviderCode = z.infer<typeof providerCodeSchema>;
 
 export const baseProviderSchema = z.object({
   provider: providerCodeSchema,
@@ -63,8 +64,11 @@ export const providerModelsQuerySchema = {
   }),
 };
 
-export type ProviderCode = z.infer<typeof providerCodeSchema>;
-export type ActivateProviderRequest = z.infer<typeof baseProviderSchema>;
+type BaseProviderSchema = z.infer<typeof baseProviderSchema>;
+
+export type ActivateProviderRequest = Omit<BaseProviderSchema, 'provider'> & {
+  provider: ProviderCode;
+};
 export type UpdateProviderRequest = z.infer<typeof updateProviderSchema.body>;
 export type ProviderParams = z.infer<typeof providerParamsSchema.params>;
 export type ProviderModelsQuery = z.infer<typeof providerModelsQuerySchema.query>;

--- a/pocketllm-backend/src/provider-configs/provider-configs.service.ts
+++ b/pocketllm-backend/src/provider-configs/provider-configs.service.ts
@@ -4,24 +4,14 @@ import { EncryptionService } from '../common/services/encryption.service';
 import { HashService } from '../common/services/hash.service';
 import { OllamaService } from '../providers/ollama.service';
 import { OpenRouterService } from '../providers/openrouter.service';
-import { ProviderCode } from '../api/v1/schemas/providers.schemas';
+import {
+  ActivateProviderRequest,
+  ProviderCode,
+  UpdateProviderRequest,
+} from '../api/v1/schemas/providers.schemas';
 
-interface ActivateProviderInput {
-  provider: ProviderCode;
-  apiKey?: string;
-  baseUrl?: string;
-  metadata?: Record<string, any> | null;
-  displayName?: string | null;
-  isActive?: boolean;
-}
-
-interface UpdateProviderInput {
-  apiKey?: string | null;
-  baseUrl?: string | null;
-  metadata?: Record<string, any> | null;
-  displayName?: string | null;
-  isActive?: boolean;
-}
+type ActivateProviderInput = ActivateProviderRequest;
+type UpdateProviderInput = UpdateProviderRequest;
 
 @Injectable()
 export class ProviderConfigsService {


### PR DESCRIPTION
## Summary
- ensure the provider activation request type always carries a provider code
- reuse the schema-derived types inside the provider config service to keep controller and service contracts in sync

## Testing
- npm run build *(fails: `nest` CLI not found in container)*
- npm run lint *(fails: ESLint 9 requires eslint.config.js in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4199e2990832d867523c04df49efb