### PR TITLE
Fix Vercel deployment routing and document setup

### DIFF
--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -121,6 +121,41 @@ The server will start on `http://localhost:8000` with:
 - 📚 API Documentation: `http://localhost:8000/api/docs`
 - 🔗 API Base URL: `http://localhost:8000/v1`
 
+## ☁️ Deploying to Vercel
+
+The backend can be deployed as a Vercel Serverless Function. Use the following settings when creating a new project from GitHub:
+
+1. **Framework preset:** `Other`
+2. **Root Directory:** `pocketllm-backend`
+3. **Build Command:** `npm run vercel-build`
+4. **Install Command:** `npm install`
+5. **Output Directory:** _Leave empty_. The serverless function defined in `api/index.ts` handles all routing, so you do not serve a static build artifact.
+
+> ✅ **Tip:** The provided `vercel.json` already rewrites every request to the serverless handler so hitting the root of your Vercel deployment will execute the NestJS application.
+
+### Required Environment Variables on Vercel
+
+Configure the following variables in the Vercel dashboard (Project Settings → Environment Variables):
+
+| Variable | Description |
+| --- | --- |
+| `SUPABASE_URL` | Supabase project URL |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key |
+| `ENCRYPTION_KEY` | 32-byte secret for encrypting provider credentials |
+| `OPENROUTER_APP_URL` | (Optional) URL of the client application for OpenRouter attribution |
+| `OPENROUTER_APP_NAME` | (Optional) Application name for OpenRouter attribution |
+| `CORS_ORIGIN` | The frontend origin allowed to call the API. Use your Flutter web domain when targeting Flutter Web. For mobile/desktop Flutter builds (which do not use CORS), you can keep the default `*`. |
+
+### Verifying the Deployment
+
+After Vercel finishes building:
+
+1. Visit `https://<your-vercel-domain>/` – you should see a JSON payload confirming that the API is running and that all endpoints live under `/v1`.
+2. Visit `https://<your-vercel-domain>/health` to perform a lightweight health check that Vercel can use for monitoring.
+3. Call one of the actual API routes such as `https://<your-vercel-domain>/v1/auth/signin` to confirm that routing (and the `/v1` prefix) works as expected.
+
+If you encounter a 404, double-check that the project root is set to `pocketllm-backend` and that the output directory is left blank. Setting an output directory forces Vercel to treat the build as a static site and bypass the serverless handler, which results in the `404: NOT_FOUND` error.
+
 ## 📖 API Documentation
 
 The API is fully documented with Swagger/OpenAPI. Once the server is running, visit:

--- a/pocketllm-backend/api/index.ts
+++ b/pocketllm-backend/api/index.ts
@@ -1,12 +1,34 @@
-import { createApp } from '../src/main';
+import type { INestApplication } from '@nestjs/common';
+import type { Request, Response } from 'express';
 
-// Create the NestJS app instance
-const appPromise = createApp().then(async (app) => {
+type CreateAppFn = () => Promise<INestApplication>;
+
+function resolveCreateApp(): CreateAppFn {
+  try {
+    // Prefer the compiled NestJS bundle produced during `npm run build`
+    // because it is what the Vercel runtime executes in production.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { createApp } = require('../dist/main') as { createApp: CreateAppFn };
+    if (typeof createApp === 'function') {
+      return createApp;
+    }
+  } catch (error) {
+    if (process.env.NODE_ENV !== 'production') {
+      console.warn('Falling back to the TypeScript sources for createApp().', error);
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { createApp } = require('../src/main') as { createApp: CreateAppFn };
+  return createApp;
+}
+
+const appPromise = resolveCreateApp()().then(async (app) => {
   await app.init();
   return app;
 });
 
-export default async function handler(req, res) {
+export default async function handler(req: Request, res: Response) {
   const app = await appPromise;
   app.getHttpAdapter().getInstance()(req, res);
 }

--- a/pocketllm-backend/src/app.controller.ts
+++ b/pocketllm-backend/src/app.controller.ts
@@ -1,0 +1,22 @@
+import { Controller, Get } from '@nestjs/common';
+
+@Controller()
+export class AppController {
+  @Get()
+  getRoot() {
+    return {
+      status: 'ok',
+      message: 'PocketLLM backend is running. All REST endpoints are available under the /v1 prefix.',
+      docs: '/api/docs',
+      health: '/health',
+    };
+  }
+
+  @Get('health')
+  getHealth() {
+    return {
+      status: 'ok',
+      timestamp: new Date().toISOString(),
+    };
+  }
+}

--- a/pocketllm-backend/src/app.module.ts
+++ b/pocketllm-backend/src/app.module.ts
@@ -7,6 +7,7 @@ import { UsersModule } from './users/users.module';
 import { ChatsModule } from './chats/chats.module';
 import { JobsModule } from './jobs/jobs.module';
 import { ApiModule } from './api/api.module';
+import { AppController } from './app.controller';
 
 @Module({
   imports: [
@@ -19,5 +20,6 @@ import { ApiModule } from './api/api.module';
     JobsModule,
     ApiModule,
   ],
+  controllers: [AppController],
 })
 export class AppModule {}

--- a/pocketllm-backend/src/main.ts
+++ b/pocketllm-backend/src/main.ts
@@ -1,5 +1,5 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { RequestMethod, ValidationPipe } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
@@ -22,7 +22,12 @@ export async function createApp() {
   });
 
   // Set global prefix for all routes
-  app.setGlobalPrefix(apiPrefix);
+  app.setGlobalPrefix(apiPrefix, {
+    exclude: [
+      { path: '/', method: RequestMethod.GET },
+      { path: '/health', method: RequestMethod.GET },
+    ],
+  });
 
   // Global validation pipe
   app.useGlobalPipes(


### PR DESCRIPTION
## Summary
- resolve the Vercel serverless handler from the compiled Nest build when available and fall back to TS sources locally
- add a root and `/health` controller plus prefix exclusions so deployments respond with guidance instead of 404s
- document the correct Vercel configuration, environment variables, and deployment verification steps in the backend README

## Testing
- ⚠️ `npm install` *(fails in the execution environment with 403 responses from registry.npmjs.org, so build/lint commands could not be run)*

------
https://chatgpt.com/codex/tasks/task_e_68d42b8dacb0832d805c439033339da5