### PR TITLE
Add backend fallback support and update API docs

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -823,9 +823,11 @@ To exercise the NestJS backend from a physical phone or tablet:
 2. **Expose the backend on the LAN.** The NestJS server already listens on `0.0.0.0`; confirm it is reachable by visiting `http://<your-computer-ip>:8000/api/docs` from another device.
 3. **Run Flutter with the LAN URL.** When launching the app, override the backend base URL so API calls target your desktop instead of `localhost`:
    ```bash
-   flutter run --dart-define=POCKETLLM_BACKEND_URL=http://<your-computer-ip>:8000/v1
+   flutter run \
+     --dart-define=BACKEND_BASE_URL=http://<your-computer-ip>:8000 \
+     --dart-define=BACKEND_API_SUFFIX=v1
    ```
-   Replace `<your-computer-ip>` with the IPv4 address shown by `ipconfig` (Windows) or `ifconfig`/`ip addr` (macOS/Linux).
+   Add `--dart-define=FALLBACK_BACKEND_URL=<optional-backup-url>` if you want to supply a secondary server. Replace `<your-computer-ip>` with the IPv4 address shown by `ipconfig` (Windows) or `ifconfig`/`ip addr` (macOS/Linux). The legacy `POCKETLLM_BACKEND_URL` flag still works and can be used if you prefer providing the full URL (for example `http://<your-computer-ip>:8000/v1`).
 4. **Verify authentication calls.** After the app starts, the Sign In and Sign Up flows will send requests to the configured backend URL. Monitor the NestJS console logs to confirm the `/v1/auth/signup` and `/v1/auth/signin` handlers execute when you tap the respective buttons in the mobile UI.
 
 If the device cannot reach the backend, double-check VPNs or firewalls, and ensure the mobile network does not isolate clients (some public hotspots do).

--- a/lib/services/backend_api_service.dart
+++ b/lib/services/backend_api_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:http/http.dart' as http;
@@ -8,10 +9,7 @@ class BackendApiService {
   static final BackendApiService _instance = BackendApiService._internal();
   factory BackendApiService() => _instance;
 
-  static const String _baseUrl = String.fromEnvironment(
-    'POCKETLLM_BACKEND_URL',
-    defaultValue: 'http://localhost:8000/v1',
-  );
+  static final List<String> _baseUrls = _resolveBaseUrls();
 
   final FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
 
@@ -29,43 +27,203 @@ class BackendApiService {
     return headers;
   }
 
-  Uri _resolveUri(String path, [Map<String, String>? query]) {
-    final normalized = path.startsWith('/') ? path.substring(1) : path;
-    return Uri.parse('$_baseUrl/$normalized').replace(queryParameters: query);
+  Uri _resolveUri(String baseUrl, String path, [Map<String, String>? query]) {
+    final normalizedPath = path.startsWith('/') ? path.substring(1) : path;
+    return Uri.parse('$baseUrl/$normalizedPath').replace(queryParameters: query);
   }
 
   Future<dynamic> get(String path, {Map<String, String>? query}) async {
-    final response = await http.get(
-      _resolveUri(path, query),
-      headers: await _buildHeaders(),
+    final headers = await _buildHeaders();
+    final response = await _executeWithFallback(
+      (baseUrl) => http.get(
+        _resolveUri(baseUrl, path, query),
+        headers: headers,
+      ),
     );
     return _handleResponse(response);
   }
 
   Future<dynamic> post(String path, {Map<String, dynamic>? body}) async {
-    final response = await http.post(
-      _resolveUri(path),
-      headers: await _buildHeaders(),
-      body: jsonEncode(body ?? {}),
+    final headers = await _buildHeaders();
+    final response = await _executeWithFallback(
+      (baseUrl) => http.post(
+        _resolveUri(baseUrl, path),
+        headers: headers,
+        body: jsonEncode(body ?? {}),
+      ),
     );
     return _handleResponse(response);
   }
 
   Future<dynamic> patch(String path, {Map<String, dynamic>? body}) async {
-    final response = await http.patch(
-      _resolveUri(path),
-      headers: await _buildHeaders(),
-      body: jsonEncode(body ?? {}),
+    final headers = await _buildHeaders();
+    final response = await _executeWithFallback(
+      (baseUrl) => http.patch(
+        _resolveUri(baseUrl, path),
+        headers: headers,
+        body: jsonEncode(body ?? {}),
+      ),
     );
     return _handleResponse(response);
   }
 
   Future<dynamic> delete(String path) async {
-    final response = await http.delete(
-      _resolveUri(path),
-      headers: await _buildHeaders(),
+    final headers = await _buildHeaders();
+    final response = await _executeWithFallback(
+      (baseUrl) => http.delete(
+        _resolveUri(baseUrl, path),
+        headers: headers,
+      ),
     );
     return _handleResponse(response);
+  }
+
+  static List<String> _resolveBaseUrls() {
+    final suffix = _resolveApiSuffix();
+    final urls = <String>[];
+    final seen = <String>{};
+
+    void addCandidate(String raw) {
+      final normalized = _normalizeBaseUrl(raw);
+      if (normalized == null) {
+        return;
+      }
+
+      final withSuffix = _ensureSuffix(normalized, suffix);
+      if (seen.add(withSuffix)) {
+        urls.add(withSuffix);
+      }
+    }
+
+    const primaryCandidates = [
+      String.fromEnvironment('POCKETLLM_BACKEND_URL', defaultValue: ''),
+      String.fromEnvironment('POCKETLLM_BACKEND_BASE_URL', defaultValue: ''),
+      String.fromEnvironment('POCKETLLM_BACKEND_ROOT_URL', defaultValue: ''),
+      String.fromEnvironment('BACKEND_BASE_URL', defaultValue: ''),
+    ];
+
+    for (final candidate in primaryCandidates) {
+      addCandidate(candidate);
+    }
+
+    if (urls.isEmpty) {
+      addCandidate('http://localhost:8000');
+    }
+
+    const fallbackCandidates = [
+      String.fromEnvironment('POCKETLLM_FALLBACK_BACKEND_URL', defaultValue: ''),
+      String.fromEnvironment('FALLBACK_BACKEND_URL', defaultValue: ''),
+    ];
+
+    for (final candidate in fallbackCandidates) {
+      addCandidate(candidate);
+    }
+
+    return List.unmodifiable(urls);
+  }
+
+  static String _resolveApiSuffix() {
+    const suffixCandidates = [
+      String.fromEnvironment('POCKETLLM_BACKEND_SUFFIX', defaultValue: ''),
+      String.fromEnvironment('POCKETLLM_BACKEND_API_SUFFIX', defaultValue: ''),
+      String.fromEnvironment('BACKEND_API_SUFFIX', defaultValue: ''),
+    ];
+
+    for (final candidate in suffixCandidates) {
+      final trimmed = candidate.trim();
+      if (trimmed.isNotEmpty) {
+        return trimmed;
+      }
+    }
+
+    return 'v1';
+  }
+
+  static String? _normalizeBaseUrl(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return null;
+    }
+
+    var normalized = trimmed;
+    while (normalized.endsWith('/')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized;
+  }
+
+  static String _ensureSuffix(String baseUrl, String suffix) {
+    final sanitizedSuffix = suffix.trim();
+    if (sanitizedSuffix.isEmpty) {
+      return baseUrl;
+    }
+
+    final normalizedSuffix = sanitizedSuffix.startsWith('/')
+        ? sanitizedSuffix.substring(1)
+        : sanitizedSuffix;
+
+    if (normalizedSuffix.isEmpty) {
+      return baseUrl;
+    }
+
+    if (baseUrl.toLowerCase().endsWith('/${normalizedSuffix.toLowerCase()}')) {
+      return baseUrl;
+    }
+
+    return '$baseUrl/$normalizedSuffix';
+  }
+
+  typedef _RequestInvoker = Future<http.Response> Function(String baseUrl);
+
+  Future<http.Response> _executeWithFallback(_RequestInvoker invoke) async {
+    http.Response? lastResponse;
+    Object? lastError;
+    StackTrace? lastStackTrace;
+
+    for (var index = 0; index < _baseUrls.length; index++) {
+      final baseUrl = _baseUrls[index];
+      final isLastAttempt = index == _baseUrls.length - 1;
+
+      try {
+        final response = await invoke(baseUrl);
+
+        if (response.statusCode >= 500 && !isLastAttempt) {
+          lastResponse = response;
+          debugPrint(
+            'BackendApiService: Received status ${response.statusCode} from $baseUrl. Trying fallback backend.',
+          );
+          continue;
+        }
+
+        return response;
+      } catch (error, stackTrace) {
+        lastError = error;
+        lastStackTrace = stackTrace;
+
+        if (!isLastAttempt) {
+          debugPrint(
+            'BackendApiService: Request to $baseUrl failed ($error). Trying fallback backend.',
+          );
+          continue;
+        }
+
+        if (lastResponse != null) {
+          return lastResponse!;
+        }
+
+        Error.throwWithStackTrace(error, stackTrace);
+      }
+    }
+
+    if (lastResponse != null) {
+      return lastResponse!;
+    }
+
+    if (lastError != null && lastStackTrace != null) {
+      Error.throwWithStackTrace(lastError!, lastStackTrace!);
+    }
+
+    throw StateError('No backend URL configured.');
   }
 
   dynamic _handleResponse(http.Response response) {


### PR DESCRIPTION
## Summary
- update the Flutter backend API client to support primary and fallback backend URLs with an overridable API suffix
- ensure every request retries against the fallback host when the primary host fails with server errors or network issues
- document the new dart-define flags for configuring base and fallback backend URLs when running the app locally

## Testing
- `flutter analyze` *(fails: flutter command is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d436688a1c832db5b0bb51e027b01f