### PR TITLE
Fix Flutter auth to use backend API endpoints

### DIFF
--- a/lib/pages/auth/auth_page.dart
+++ b/lib/pages/auth/auth_page.dart
@@ -729,9 +729,12 @@ class _AuthPageState extends State<AuthPage> {
 
         if (result.emailConfirmationRequired) {
           await _clearAuthSkipFlag();
+          final message = (result.message?.isNotEmpty ?? false)
+              ? result.message!
+              : 'Please check your email to confirm your account before continuing.';
           _showSnackBar(
             context,
-            'Please check your email to confirm your account before continuing.',
+            message,
             success: true,
           );
           widget.onLoginSuccess?.call(authState.currentUserEmail ?? email);


### PR DESCRIPTION
## Summary
- update AuthStateNotifier to call the backend auth endpoints and persist returned sessions
- normalize backend responses so success flags and errors are handled consistently
- surface backend signup messages in the UI when no session is created

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d4405a71f0832d90cb44d62b540f69