### PR TITLE
Add onboarding workflow support and expose Swagger docs

### DIFF
--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -11,6 +11,8 @@ class UserProfile extends Equatable {
   final String? heardFrom;
   final String? avatarUrl;
   final bool surveyCompleted;
+  final int? age;
+  final Map<String, dynamic>? onboarding;
   final DateTime? createdAt;
   final DateTime? updatedAt;
   final DateTime? deletionRequestedAt;
@@ -28,6 +30,8 @@ class UserProfile extends Equatable {
     this.heardFrom,
     this.avatarUrl,
     this.surveyCompleted = false,
+    this.age,
+    this.onboarding,
     this.createdAt,
     this.updatedAt,
     this.deletionRequestedAt,
@@ -60,6 +64,8 @@ class UserProfile extends Equatable {
     String? heardFrom,
     String? avatarUrl,
     bool? surveyCompleted,
+    int? age,
+    Map<String, dynamic>? onboarding,
     DateTime? createdAt,
     DateTime? updatedAt,
     DateTime? deletionRequestedAt,
@@ -77,6 +83,8 @@ class UserProfile extends Equatable {
       heardFrom: heardFrom ?? this.heardFrom,
       avatarUrl: avatarUrl ?? this.avatarUrl,
       surveyCompleted: surveyCompleted ?? this.surveyCompleted,
+      age: age ?? this.age,
+      onboarding: onboarding ?? this.onboarding,
       createdAt: createdAt ?? this.createdAt,
       updatedAt: updatedAt ?? this.updatedAt,
       deletionRequestedAt: deletionRequestedAt ?? this.deletionRequestedAt,
@@ -97,6 +105,8 @@ class UserProfile extends Equatable {
       'heard_from': heardFrom,
       'avatar_url': avatarUrl,
       'survey_completed': surveyCompleted,
+      'age': age,
+      'onboarding': onboarding,
       'created_at': createdAt?.toIso8601String(),
       'updated_at': updatedAt?.toIso8601String(),
       'deletion_requested_at': deletionRequestedAt?.toIso8601String(),
@@ -129,12 +139,31 @@ class UserProfile extends Equatable {
       heardFrom: map['heard_from'] as String?,
       avatarUrl: map['avatar_url'] as String?,
       surveyCompleted: _parseBool(map['survey_completed']),
+      age: _parseInt(map['age']),
+      onboarding: _parseOnboarding(map['onboarding']),
       createdAt: parseDate(map['created_at']),
       updatedAt: parseDate(map['updated_at']),
       deletionRequestedAt: parseDate(map['deletion_requested_at']),
       deletionScheduledFor: parseDate(map['deletion_scheduled_for']),
       deletionStatus: map['deletion_status'] as String?,
     );
+  }
+
+  static int? _parseInt(dynamic value) {
+    if (value == null) return null;
+    if (value is int) return value;
+    if (value is String && value.isNotEmpty) {
+      final parsed = int.tryParse(value);
+      return parsed;
+    }
+    return null;
+  }
+
+  static Map<String, dynamic>? _parseOnboarding(dynamic value) {
+    if (value is Map<String, dynamic>) {
+      return Map<String, dynamic>.from(value);
+    }
+    return null;
   }
 
   static bool _parseBool(dynamic value) {
@@ -159,6 +188,8 @@ class UserProfile extends Equatable {
         heardFrom,
         avatarUrl,
         surveyCompleted,
+        age,
+        onboarding,
         createdAt,
         updatedAt,
         deletionRequestedAt,

--- a/pocketllm-backend/POSTMAN_API_GUIDE.md
+++ b/pocketllm-backend/POSTMAN_API_GUIDE.md
@@ -39,9 +39,10 @@ I've created a comprehensive **Postman API Testing Guide** (`POSTMAN_API_GUIDE.m
    - `POST /v1/auth/signup` - Sign up new user
    - `POST /v1/auth/signin` - Sign in existing user
 
-2. **👤 Users (3 endpoints)**
+2. **👤 Users (4 endpoints)**
    - `GET /v1/users/profile` - Get user profile
-   - `PUT /v1/users/profile` - Update user profile  
+   - `PUT /v1/users/profile` - Update user profile
+   - `POST /v1/users/profile/onboarding` - Complete onboarding survey and store responses
    - `DELETE /v1/users/profile` - Delete user account
 
 3. **💬 Chats (7 endpoints)**
@@ -209,15 +210,27 @@ Authorization: Bearer <access_token>
   "success": true,
   "data": {
     "id": "uuid",
+    "email": "user@example.com",
     "full_name": "John Doe",
     "username": "johndoe",
     "bio": "Software developer",
     "date_of_birth": "1990-01-01",
     "profession": "Developer",
+    "heard_from": "Friend recommendation",
     "avatar_url": "https://example.com/avatar.jpg",
     "survey_completed": true,
+    "age": 34,
+    "onboarding": {
+      "primary_goal": "Build faster workflows",
+      "interests": ["Productivity", "Automation"],
+      "experience_level": "Intermediate",
+      "usage_frequency": "Daily"
+    },
     "created_at": "2023-10-27T10:00:00.000Z",
-    "updated_at": "2023-10-27T10:00:00.000Z"
+    "updated_at": "2023-10-27T10:00:00.000Z",
+    "deletion_status": "active",
+    "deletion_requested_at": null,
+    "deletion_scheduled_for": null
   }
 }
 ```
@@ -239,8 +252,17 @@ Authorization: Bearer <access_token>
   "bio": "Senior Software Developer",
   "date_of_birth": "1990-01-01",
   "profession": "Senior Developer",
+  "heard_from": "Conference booth",
   "avatar_url": "https://example.com/new_avatar.jpg",
-  "survey_completed": true
+  "survey_completed": true,
+  "age": 35,
+  "onboarding": {
+    "primary_goal": "Draft better reports",
+    "interests": ["Writing", "Productivity"],
+    "experience_level": "Advanced",
+    "usage_frequency": "Weekly",
+    "other_notes": "Prefers concise prompts"
+  }
 }
 ```
 
@@ -250,15 +272,88 @@ Authorization: Bearer <access_token>
   "success": true,
   "data": {
     "id": "uuid",
+    "email": "user@example.com",
     "full_name": "John Doe Updated",
     "username": "johndoe_new",
     "bio": "Senior Software Developer",
     "date_of_birth": "1990-01-01",
     "profession": "Senior Developer",
+    "heard_from": "Conference booth",
     "avatar_url": "https://example.com/new_avatar.jpg",
     "survey_completed": true,
+    "age": 35,
+    "onboarding": {
+      "primary_goal": "Draft better reports",
+      "interests": ["Writing", "Productivity"],
+      "experience_level": "Advanced",
+      "usage_frequency": "Weekly",
+      "other_notes": "Prefers concise prompts"
+    },
     "created_at": "2023-10-27T10:00:00.000Z",
-    "updated_at": "2023-10-27T11:00:00.000Z"
+    "updated_at": "2023-10-27T11:00:00.000Z",
+    "deletion_status": "active",
+    "deletion_requested_at": null,
+    "deletion_scheduled_for": null
+  }
+}
+```
+
+### POST /v1/users/profile/onboarding
+**Group:** users
+**URL:** `http://localhost:8000/v1/users/profile/onboarding`
+
+**Headers:**
+```
+Authorization: Bearer <access_token>
+```
+
+**Body (JSON):**
+```json
+{
+  "full_name": "John Doe",
+  "username": "johndoe",
+  "bio": "Software developer",
+  "date_of_birth": "1990-01-01",
+  "profession": "Developer",
+  "heard_from": "Friend recommendation",
+  "avatar_url": "https://example.com/avatar.jpg",
+  "age": 34,
+  "onboarding": {
+    "primary_goal": "Build faster workflows",
+    "interests": ["Productivity", "Automation"],
+    "experience_level": "Intermediate",
+    "usage_frequency": "Daily"
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "uuid",
+    "email": "user@example.com",
+    "full_name": "John Doe",
+    "username": "johndoe",
+    "bio": "Software developer",
+    "date_of_birth": "1990-01-01",
+    "profession": "Developer",
+    "heard_from": "Friend recommendation",
+    "avatar_url": "https://example.com/avatar.jpg",
+    "survey_completed": true,
+    "age": 34,
+    "onboarding": {
+      "primary_goal": "Build faster workflows",
+      "interests": ["Productivity", "Automation"],
+      "experience_level": "Intermediate",
+      "usage_frequency": "Daily"
+    },
+    "created_at": "2023-10-27T10:00:00.000Z",
+    "updated_at": "2023-10-27T10:05:00.000Z",
+    "deletion_status": "active",
+    "deletion_requested_at": null,
+    "deletion_scheduled_for": null
   }
 }
 ```

--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -98,6 +98,10 @@ SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 # Encryption
 ENCRYPTION_KEY=a_strong_32_byte_secret_key_for_encrypting_api_keys
 
+# API Documentation
+ENABLE_SWAGGER_DOCS=true
+SWAGGER_DOCS_PATH=api/docs
+
 # Third-party attribution (required by OpenRouter)
 OPENROUTER_APP_URL=https://your-app-domain.example
 OPENROUTER_APP_NAME=PocketLLM
@@ -118,7 +122,7 @@ npm run start:debug
 ```
 
 The server will start on `http://localhost:8000` with:
-- 📚 API Documentation: `http://localhost:8000/api/docs`
+- 📚 API Documentation: `http://localhost:8000/api/docs` (configurable via `ENABLE_SWAGGER_DOCS` / `SWAGGER_DOCS_PATH`)
 - 🔗 API Base URL: `http://localhost:8000/v1`
 
 ## ☁️ Deploying to Vercel
@@ -164,7 +168,7 @@ The API is fully documented with Swagger/OpenAPI. Once the server is running, vi
 ### Key Endpoints
 
 - **Authentication**: `/v1/auth/signup`, `/v1/auth/signin`
-- **Users**: `/v1/users/profile`
+- **Users**: `/v1/users/profile`, `/v1/users/profile/onboarding`
 - **Chats**: `/v1/chats`, `/v1/chats/:id/messages`
 - **Providers**: `/v1/providers`, `/v1/providers/activate`, `/v1/providers/:provider`
 - **Models**: `/v1/models`, `/v1/models/import`, `/v1/models/:modelId`
@@ -178,6 +182,7 @@ by the Chats and Jobs controllers so every user-scoped route enforces authentica
 
 - `GET /v1/users/profile` – Fetches the current user's profile row from the `profiles` table.
 - `PUT /v1/users/profile` – Updates the authenticated user's profile data while handling duplicate usernames.
+- `POST /v1/users/profile/onboarding` – Captures onboarding responses (age, goals, interests) and marks the profile as survey complete.
 - `DELETE /v1/users/profile` – Permanently removes the Supabase user and cascades the related profile record.
 
 The `UsersService` performs an additional user ID check and returns a `401 Unauthorized` response when the guard is bypassed or

--- a/pocketllm-backend/db/migrations/202502150001_onboarding_profile_fields.sql
+++ b/pocketllm-backend/db/migrations/202502150001_onboarding_profile_fields.sql
@@ -1,0 +1,4 @@
+-- Add onboarding support fields to profiles table
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS age INTEGER CHECK (age IS NULL OR (age >= 13 AND age <= 120)),
+  ADD COLUMN IF NOT EXISTS onboarding_responses JSONB;

--- a/pocketllm-backend/src/auth/auth.controller.ts
+++ b/pocketllm-backend/src/auth/auth.controller.ts
@@ -22,7 +22,11 @@ export class AuthController {
   })
   @ApiResponse({
     status: 400,
-    description: 'Bad request - invalid input or user already exists',
+    description: 'Bad request - invalid input',
+  })
+  @ApiResponse({
+    status: 409,
+    description: 'Conflict - user already exists',
   })
   async signUp(@Body() signUpDto: SignUpRequest): Promise<AuthResponse> {
     return this.authService.signUp(signUpDto);

--- a/pocketllm-backend/src/config/configuration.ts
+++ b/pocketllm-backend/src/config/configuration.ts
@@ -15,4 +15,13 @@ export default registerAs('app', () => ({
     prefix: 'v1',
     version: '1.0.0',
   },
+  docs: {
+    enabled:
+      process.env.ENABLE_SWAGGER_DOCS?.toLowerCase() === 'false'
+        ? false
+        : process.env.ENABLE_SWAGGER_DOCS?.toLowerCase() === 'true'
+        ? true
+        : true,
+    path: process.env.SWAGGER_DOCS_PATH || 'api/docs',
+  },
 }));

--- a/pocketllm-backend/src/users/dto/complete-onboarding.dto.ts
+++ b/pocketllm-backend/src/users/dto/complete-onboarding.dto.ts
@@ -1,44 +1,34 @@
+import { ApiProperty } from '@nestjs/swagger';
 import {
-  IsString,
-  IsOptional,
-  IsUrl,
   IsBoolean,
-  MinLength,
-  MaxLength,
-  Matches,
+  IsDateString,
   IsInt,
+  IsOptional,
+  IsString,
+  IsUrl,
+  MaxLength,
   Min,
   Max,
+  MinLength,
   ValidateNested,
 } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { OnboardingDetailsDto } from './onboarding-details.dto';
 
-export class UpdateProfileDto {
-  @ApiProperty({
-    description: 'User full name',
-    example: 'John Doe',
-    required: false,
-  })
-  @IsOptional()
+export class CompleteOnboardingDto {
+  @ApiProperty({ description: 'User full name', example: 'Ada Lovelace' })
   @IsString()
   @MinLength(1, { message: 'Full name cannot be empty.' })
-  full_name?: string | null;
+  full_name!: string;
 
-  @ApiProperty({
-    description: 'Username (minimum 3 characters)',
-    example: 'johndoe',
-    required: false,
-  })
-  @IsOptional()
+  @ApiProperty({ description: 'Unique username', example: 'adalovelace' })
   @IsString()
   @MinLength(3, { message: 'Username must be at least 3 characters.' })
-  username?: string | null;
+  username!: string;
 
   @ApiProperty({
-    description: 'User bio (maximum 500 characters)',
-    example: 'Software developer passionate about AI',
+    description: 'Short biography',
+    example: 'Working on AI productivity workflows',
     required: false,
   })
   @IsOptional()
@@ -47,20 +37,15 @@ export class UpdateProfileDto {
   bio?: string | null;
 
   @ApiProperty({
-    description: 'Date of birth in YYYY-MM-DD format',
-    example: '1990-01-15',
+    description: 'Date of birth in ISO 8601 format',
+    example: '1995-06-15',
     required: false,
   })
   @IsOptional()
-  @IsString()
-  @Matches(/^\d{4}-\d{2}-\d{2}$/, { message: 'Date of birth must be in YYYY-MM-DD format.' })
+  @IsDateString({}, { message: 'Date of birth must be a valid ISO date string.' })
   date_of_birth?: string | null;
 
-  @ApiProperty({
-    description: 'User profession',
-    example: 'Software Engineer',
-    required: false,
-  })
+  @ApiProperty({ description: 'Profession', example: 'Software Engineer', required: false })
   @IsOptional()
   @IsString()
   profession?: string | null;
@@ -75,8 +60,8 @@ export class UpdateProfileDto {
   heard_from?: string | null;
 
   @ApiProperty({
-    description: 'Avatar URL',
-    example: 'https://example.com/avatar.jpg',
+    description: 'Avatar URL or selected asset path',
+    example: 'https://example.com/avatar.png',
     required: false,
   })
   @IsOptional()
@@ -84,21 +69,11 @@ export class UpdateProfileDto {
   avatar_url?: string | null;
 
   @ApiProperty({
-    description: 'Whether user has completed the survey',
-    example: true,
-    required: false,
-  })
-  @IsOptional()
-  @IsBoolean()
-  survey_completed?: boolean;
-
-  @ApiProperty({
     description: 'User age',
-    example: 27,
+    example: 28,
     required: false,
     minimum: 13,
     maximum: 120,
-    nullable: true,
   })
   @IsOptional()
   @IsInt()
@@ -107,10 +82,18 @@ export class UpdateProfileDto {
   age?: number | null;
 
   @ApiProperty({
-    description: 'Structured onboarding responses captured during signup',
+    description: 'Whether onboarding survey is completed',
+    example: true,
+    required: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  survey_completed?: boolean;
+
+  @ApiProperty({
+    description: 'Structured onboarding answers',
     required: false,
     type: () => OnboardingDetailsDto,
-    nullable: true,
   })
   @IsOptional()
   @ValidateNested()

--- a/pocketllm-backend/src/users/dto/onboarding-details.dto.ts
+++ b/pocketllm-backend/src/users/dto/onboarding-details.dto.ts
@@ -1,0 +1,51 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsOptional, IsString } from 'class-validator';
+
+export class OnboardingDetailsDto {
+  @ApiProperty({
+    description: 'Primary goal or reason for using PocketLLM',
+    example: 'Improve daily productivity with AI assistance',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  primary_goal?: string;
+
+  @ApiProperty({
+    description: 'Topics or interests the user cares about',
+    example: ['Productivity', 'Coding'],
+    required: false,
+    type: [String],
+  })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  interests?: string[];
+
+  @ApiProperty({
+    description: 'User self-reported experience level with AI tools',
+    example: 'Intermediate',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  experience_level?: string;
+
+  @ApiProperty({
+    description: 'How frequently the user expects to use the product',
+    example: 'Daily',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  usage_frequency?: string;
+
+  @ApiProperty({
+    description: 'Any additional notes captured during onboarding',
+    example: 'Prefers concise answers and actionable steps.',
+    required: false,
+  })
+  @IsOptional()
+  @IsString()
+  other_notes?: string;
+}

--- a/pocketllm-backend/src/users/dto/profile.dto.ts
+++ b/pocketllm-backend/src/users/dto/profile.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { OnboardingDetailsDto } from './onboarding-details.dto';
 
 export class ProfileDto {
   @ApiProperty({ description: 'Profile ID (UUID)' })
@@ -27,6 +28,16 @@ export class ProfileDto {
 
   @ApiProperty({ description: 'Avatar URL', nullable: true })
   avatar_url: string | null;
+
+  @ApiProperty({ description: 'User age', nullable: true, example: 27 })
+  age: number | null;
+
+  @ApiProperty({
+    description: 'Structured onboarding responses captured during signup',
+    nullable: true,
+    type: () => OnboardingDetailsDto,
+  })
+  onboarding: OnboardingDetailsDto | null;
 
   @ApiProperty({ description: 'Whether user has completed the survey' })
   survey_completed: boolean;

--- a/pocketllm-backend/src/users/users.controller.ts
+++ b/pocketllm-backend/src/users/users.controller.ts
@@ -1,9 +1,10 @@
-import { Controller, Get, Put, Delete, Body, UseGuards, Req } from '@nestjs/common';
+import { Controller, Get, Put, Delete, Post, Body, UseGuards, Req } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBody, ApiBearerAuth } from '@nestjs/swagger';
 import { UsersService } from './users.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ProfileDto } from './dto/profile.dto';
 import { SupabaseAuthGuard } from '../auth/guards/supabase-auth.guard';
+import { CompleteOnboardingDto } from './dto/complete-onboarding.dto';
 
 @ApiTags('Users')
 @Controller('users')
@@ -32,7 +33,7 @@ export class UsersController {
   }
 
   @Put('profile')
-  @ApiOperation({ 
+  @ApiOperation({
     summary: 'Update user profile',
     description: 'Update the current user\'s profile information'
   })
@@ -52,6 +53,25 @@ export class UsersController {
   ): Promise<ProfileDto> {
     const userId = request.user?.id;
     return this.usersService.updateProfile(userId, updateProfileDto);
+  }
+
+  @Post('profile/onboarding')
+  @ApiOperation({
+    summary: 'Complete onboarding survey',
+    description: 'Capture onboarding responses and mark the profile as completed',
+  })
+  @ApiBody({ type: CompleteOnboardingDto })
+  @ApiResponse({
+    status: 200,
+    description: 'Onboarding data saved successfully',
+    type: ProfileDto,
+  })
+  async completeOnboarding(
+    @Req() request: any,
+    @Body() completeOnboardingDto: CompleteOnboardingDto,
+  ): Promise<ProfileDto> {
+    const userId = request.user?.id;
+    return this.usersService.completeOnboarding(userId, completeOnboardingDto);
   }
 
   @Delete('profile')

--- a/pocketllm-backend/src/users/users.service.ts
+++ b/pocketllm-backend/src/users/users.service.ts
@@ -10,6 +10,8 @@ import { SupabaseService } from '../common/services/supabase.service';
 import { UpdateProfileDto } from './dto/update-profile.dto';
 import { ProfileDto } from './dto/profile.dto';
 import { User } from '@supabase/supabase-js';
+import { CompleteOnboardingDto } from './dto/complete-onboarding.dto';
+import { OnboardingDetailsDto } from './dto/onboarding-details.dto';
 
 @Injectable()
 export class UsersService {
@@ -28,30 +30,21 @@ export class UsersService {
     }
 
     try {
-      const { data, error } = await this.supabaseService
-        .from('profiles')
-        .select('*')
-        .eq('id', userId)
-        .maybeSingle();
-
-      if (error) {
-        this.logger.error('Supabase get profile error:', error);
-        throw new NotFoundException('Profile not found.');
-      }
-
-      if (!data) {
-        throw new NotFoundException('Profile not found.');
-      }
-
       const authUser = await this.fetchAuthUser(userId);
-      return this.normalizeProfile(data, authUser);
+      const profileRecord = await this.ensureProfileExists(userId, authUser);
+
+      if (!profileRecord) {
+        throw new NotFoundException('Profile not found.');
+      }
+
+      return this.normalizeProfile(profileRecord, authUser);
     } catch (error) {
       this.logger.error('Failed to retrieve profile:', error);
-      
+
       if (error instanceof NotFoundException) {
         throw error;
       }
-      
+
       throw new InternalServerErrorException('Failed to retrieve profile.');
     }
   }
@@ -68,9 +61,19 @@ export class UsersService {
     }
 
     try {
+      const authUser = await this.fetchAuthUser(userId);
+      await this.ensureProfileExists(userId, authUser);
+
+      const updatePayload = this.buildProfileMutationPayload(updateProfileDto);
+
+      if (Object.keys(updatePayload).length === 0) {
+        const profileRecord = await this.ensureProfileExists(userId, authUser);
+        return this.normalizeProfile(profileRecord, authUser);
+      }
+
       const { data, error } = await this.supabaseService
         .from('profiles')
-        .update(updateProfileDto)
+        .update(updatePayload)
         .eq('id', userId)
         .select()
         .maybeSingle();
@@ -85,20 +88,78 @@ export class UsersService {
         throw new InternalServerErrorException('Failed to update profile.');
       }
 
-      if (!data) {
-        throw new InternalServerErrorException('Profile update did not return any data.');
-      }
-
-      const authUser = await this.fetchAuthUser(userId);
-      return this.normalizeProfile(data, authUser);
+      const profileRecord = data ?? (await this.ensureProfileExists(userId, authUser));
+      return this.normalizeProfile(profileRecord, authUser);
     } catch (error) {
       this.logger.error('Failed to update profile:', error);
-      
+
       if (error instanceof ConflictException || error instanceof InternalServerErrorException) {
         throw error;
       }
-      
+
       throw new InternalServerErrorException('An unexpected error occurred while updating the profile.');
+    }
+  }
+
+  /**
+   * Complete onboarding survey and store responses
+   * @param userId The user ID
+   * @param completeOnboardingDto Onboarding responses
+   * @returns Updated profile data
+   */
+  async completeOnboarding(
+    userId: string,
+    completeOnboardingDto: CompleteOnboardingDto,
+  ): Promise<ProfileDto> {
+    if (!userId) {
+      throw new UnauthorizedException('User authentication required to complete onboarding.');
+    }
+
+    try {
+      const authUser = await this.fetchAuthUser(userId);
+      const existingProfile = await this.ensureProfileExists(userId, authUser);
+
+      const mutation = this.buildProfileMutationPayload({
+        ...completeOnboardingDto,
+        survey_completed: completeOnboardingDto.survey_completed ?? true,
+      });
+
+      const upsertPayload = this.sanitizeProfilePayload({
+        id: userId,
+        email:
+          this.normalizeIncomingString(existingProfile?.email) ??
+          this.resolveEmailFromAuth(authUser) ??
+          `${userId}@placeholder.pocketllm`,
+        ...mutation,
+        survey_completed: completeOnboardingDto.survey_completed ?? true,
+      });
+
+      const { data, error } = await this.supabaseService
+        .from('profiles')
+        .upsert(upsertPayload, { onConflict: 'id' })
+        .select()
+        .maybeSingle();
+
+      if (error) {
+        this.logger.error('Supabase onboarding upsert error:', error);
+
+        if (error.code === '23505') {
+          throw new ConflictException('Username is already taken.');
+        }
+
+        throw new InternalServerErrorException('Failed to save onboarding responses.');
+      }
+
+      const profileRecord = data ?? (await this.ensureProfileExists(userId, authUser));
+      return this.normalizeProfile(profileRecord, authUser);
+    } catch (error) {
+      this.logger.error('Failed to save onboarding responses:', error);
+
+      if (error instanceof ConflictException || error instanceof InternalServerErrorException) {
+        throw error;
+      }
+
+      throw new InternalServerErrorException('An unexpected error occurred while saving onboarding responses.');
     }
   }
 
@@ -148,6 +209,111 @@ export class UsersService {
     }
   }
 
+  private async ensureProfileExists(userId: string, authUser?: User | null): Promise<any> {
+    const { data, error } = await this.supabaseService
+      .from('profiles')
+      .select('*')
+      .eq('id', userId)
+      .maybeSingle();
+
+    if (error && error.code !== 'PGRST116') {
+      this.logger.error(`Failed to look up profile for user ${userId}:`, error);
+      throw new InternalServerErrorException('Unable to verify profile state.');
+    }
+
+    if (data) {
+      return data;
+    }
+
+    const resolvedAuthUser = authUser ?? (await this.fetchAuthUser(userId));
+    const fallbackEmail =
+      this.resolveEmailFromAuth(resolvedAuthUser) ?? `${userId}@placeholder.pocketllm`;
+
+    const profilePayload = this.sanitizeProfilePayload({
+      id: userId,
+      email: fallbackEmail,
+      full_name: this.normalizeIncomingString(resolvedAuthUser?.user_metadata?.full_name),
+      username:
+        this.normalizeIncomingString(resolvedAuthUser?.user_metadata?.username) ??
+        this.normalizeIncomingString(resolvedAuthUser?.user_metadata?.user_name),
+      bio: null,
+      date_of_birth: null,
+      profession: this.normalizeIncomingString(resolvedAuthUser?.user_metadata?.profession),
+      heard_from: this.normalizeIncomingString(resolvedAuthUser?.user_metadata?.heard_from),
+      avatar_url:
+        this.normalizeIncomingString(resolvedAuthUser?.user_metadata?.avatar_url) ??
+        this.normalizeIncomingString(resolvedAuthUser?.user_metadata?.avatarUrl),
+      survey_completed: false,
+      deletion_status: 'active',
+    });
+
+    const { data: created, error: insertError } = await this.supabaseService
+      .from('profiles')
+      .upsert(profilePayload, { onConflict: 'id' })
+      .select()
+      .maybeSingle();
+
+    if (insertError) {
+      this.logger.error(`Failed to provision profile for user ${userId}:`, insertError);
+      throw new InternalServerErrorException('Unable to create user profile.');
+    }
+
+    return created;
+  }
+
+  private buildProfileMutationPayload(input: Record<string, any>): Record<string, any> {
+    const payload: Record<string, any> = {};
+
+    if (Object.prototype.hasOwnProperty.call(input, 'full_name')) {
+      payload.full_name = this.normalizeIncomingString(input.full_name);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'username')) {
+      payload.username = this.normalizeIncomingString(input.username);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'bio')) {
+      payload.bio = this.normalizeIncomingString(input.bio);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'date_of_birth')) {
+      payload.date_of_birth = this.formatDateInput(input.date_of_birth);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'profession')) {
+      payload.profession = this.normalizeIncomingString(input.profession);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'heard_from')) {
+      payload.heard_from = this.normalizeIncomingString(input.heard_from);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'avatar_url')) {
+      payload.avatar_url = this.normalizeIncomingString(input.avatar_url);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'survey_completed')) {
+      const value = input.survey_completed;
+      payload.survey_completed = value === null || value === undefined ? null : Boolean(value);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'age')) {
+      payload.age = this.parseAge(input.age);
+    }
+
+    if (Object.prototype.hasOwnProperty.call(input, 'onboarding')) {
+      payload.onboarding_responses = this.prepareOnboardingResponses(input.onboarding);
+    }
+
+    return this.sanitizeProfilePayload(payload);
+  }
+
+  private sanitizeProfilePayload(payload: Record<string, any>): Record<string, any> {
+    return Object.fromEntries(
+      Object.entries(payload).filter(([, value]) => value !== undefined),
+    );
+  }
+
   private normalizeProfile(profile: any, authUser: User | null): ProfileDto {
     const email = this.resolveEmail(profile, authUser);
 
@@ -162,8 +328,13 @@ export class UsersService {
       heard_from: this.normalizeNullableString(profile.heard_from),
       avatar_url: this.normalizeNullableString(profile.avatar_url),
       survey_completed: Boolean(profile.survey_completed),
+      age: this.parseAge(profile.age),
+      onboarding: this.normalizeOnboardingResponses(profile.onboarding_responses),
       created_at: this.formatDate(profile.created_at) ?? new Date().toISOString(),
-      updated_at: this.formatDate(profile.updated_at) ?? this.formatDate(profile.created_at) ?? new Date().toISOString(),
+      updated_at:
+        this.formatDate(profile.updated_at) ??
+        this.formatDate(profile.created_at) ??
+        new Date().toISOString(),
       deletion_status: profile.deletion_status ?? (profile.deletion_scheduled_for ? 'pending' : 'active'),
       deletion_requested_at: this.formatDate(profile.deletion_requested_at),
       deletion_scheduled_for: this.formatDate(profile.deletion_scheduled_for),
@@ -173,23 +344,159 @@ export class UsersService {
   }
 
   private resolveEmail(profile: any, authUser: User | null): string {
-    const profileEmail = typeof profile?.email === 'string' ? profile.email : null;
+    const profileEmail = this.normalizeNullableString(profile?.email);
     if (profileEmail && !this.isPlaceholderEmail(profileEmail)) {
       return profileEmail;
     }
 
+    const authEmail = this.resolveEmailFromAuth(authUser);
+    if (authEmail) {
+      return authEmail;
+    }
+
+    return '';
+  }
+
+  private resolveEmailFromAuth(authUser: User | null): string | null {
     const candidateEmail = authUser?.email ?? authUser?.user_metadata?.email;
     if (candidateEmail && typeof candidateEmail === 'string') {
       return candidateEmail;
     }
 
-    const identityEmail = authUser?.identities?.find((identity) => identity?.identity_data?.email)?.identity_data
-      ?.email;
+    const identityEmail = authUser?.identities?.find((identity) => identity?.identity_data?.email)
+      ?.identity_data?.email;
     if (identityEmail) {
       return identityEmail;
     }
 
-    return '';
+    return null;
+  }
+
+  private prepareOnboardingResponses(
+    onboarding: OnboardingDetailsDto | null | undefined,
+  ): Record<string, any> | null {
+    if (!onboarding) {
+      return null;
+    }
+
+    const sanitizedEntries = Object.entries(onboarding).reduce<Record<string, any>>(
+      (acc, [key, value]) => {
+        if (value === undefined || value === null) {
+          return acc;
+        }
+
+        if (Array.isArray(value)) {
+          const cleanedArray = value
+            .map((entry) => (typeof entry === 'string' ? entry.trim() : entry))
+            .filter((entry) => entry !== null && entry !== undefined && entry !== '');
+
+          if (cleanedArray.length > 0) {
+            acc[key] = cleanedArray;
+          }
+          return acc;
+        }
+
+        if (typeof value === 'string') {
+          const trimmed = value.trim();
+          if (trimmed.length > 0) {
+            acc[key] = trimmed;
+          }
+          return acc;
+        }
+
+        acc[key] = value;
+        return acc;
+      },
+      {},
+    );
+
+    return Object.keys(sanitizedEntries).length > 0 ? sanitizedEntries : null;
+  }
+
+  private normalizeOnboardingResponses(value: any): OnboardingDetailsDto | null {
+    if (!value || typeof value !== 'object') {
+      return null;
+    }
+
+    const result: OnboardingDetailsDto = {};
+
+    if (typeof value.primary_goal === 'string') {
+      const trimmed = value.primary_goal.trim();
+      if (trimmed) {
+        result.primary_goal = trimmed;
+      }
+    }
+
+    if (Array.isArray(value.interests)) {
+      const interests = value.interests
+        .filter((item: any) => typeof item === 'string' && item.trim().length > 0)
+        .map((item: string) => item.trim());
+      if (interests.length > 0) {
+        result.interests = interests;
+      }
+    }
+
+    if (typeof value.experience_level === 'string') {
+      const trimmed = value.experience_level.trim();
+      if (trimmed) {
+        result.experience_level = trimmed;
+      }
+    }
+
+    if (typeof value.usage_frequency === 'string') {
+      const trimmed = value.usage_frequency.trim();
+      if (trimmed) {
+        result.usage_frequency = trimmed;
+      }
+    }
+
+    if (typeof value.other_notes === 'string') {
+      const trimmed = value.other_notes.trim();
+      if (trimmed) {
+        result.other_notes = trimmed;
+      }
+    }
+
+    return Object.keys(result).length > 0 ? result : null;
+  }
+
+  private parseAge(value: any): number | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    const parsed = Number(value);
+    if (Number.isNaN(parsed)) {
+      return null;
+    }
+
+    if (!Number.isFinite(parsed)) {
+      return null;
+    }
+
+    const rounded = Math.trunc(parsed);
+    if (rounded < 13 || rounded > 120) {
+      return null;
+    }
+
+    return rounded;
+  }
+
+  private formatDateInput(value: any): string | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+
+    if (typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value.trim())) {
+      return value.trim();
+    }
+
+    const parsed = new Date(value);
+    if (Number.isNaN(parsed.getTime())) {
+      return null;
+    }
+
+    return parsed.toISOString().substring(0, 10);
   }
 
   private formatDate(value: any): string | null {
@@ -238,6 +545,23 @@ export class UsersService {
       if (!Number.isNaN(parsed.getTime())) {
         return parsed.toISOString();
       }
+    }
+
+    return String(value);
+  }
+
+  private normalizeIncomingString(value: any): string | null | undefined {
+    if (value === undefined) {
+      return undefined;
+    }
+
+    if (value === null) {
+      return null;
+    }
+
+    if (typeof value === 'string') {
+      const trimmed = value.trim();
+      return trimmed.length > 0 ? trimmed : null;
     }
 
     return String(value);


### PR DESCRIPTION
## Summary
- prevent duplicate Supabase signups and ensure profile provisioning is robust
- add onboarding workflow support including new profile fields and API endpoint
- expose Swagger docs via configurable settings and update guides/documentation
- sync Flutter client profile handling with new fields and onboarding endpoint

## Testing
- npm run lint *(fails: ESLint v9 requires eslint.config.js migration)*
- npm run build *(fails: Nest CLI is not installed in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4d9c19344832d9887476a55bb553b