### PR TITLE
Refactor theme colors into reusable palette

### DIFF
--- a/docs/project-structure.md
+++ b/docs/project-structure.md
@@ -39,6 +39,7 @@ lib/
 │   ├── settings/          # Settings pages
 │   └── ...                # Other main pages
 ├── services/              # Business logic and state management
+├── theme/                 # Design tokens and shared theme definitions
 ├── widgets/               # Reusable widgets
 └── main.dart              # Application entry point
 ```
@@ -77,6 +78,14 @@ The [services/](../lib/services/) directory contains business logic and state ma
 - [model_state.dart](../lib/services/model_state.dart) - Model state management
 - [secure_storage_service.dart](../lib/services/secure_storage_service.dart) - Secure data storage
 - [pocket_llm_service.dart](../lib/services/pocket_llm_service.dart) - Core application service
+
+### Theme Directory
+
+The [theme/](../lib/theme/) directory centralizes design tokens and reusable
+palettes:
+
+- [app_colors.dart](../lib/theme/app_colors.dart) - Brand color tokens and
+  canonical light/dark/high-contrast schemes used by the theme service
 
 ### Widgets Directory
 

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
+import '../theme/app_colors.dart';
+
 enum AppThemeMode {
   light,
   dark,
@@ -13,68 +15,6 @@ enum ColorSchemeType {
   standard,
   highContrast,
   custom,
-}
-
-class AppColorScheme {
-  final Color primary;
-  final Color primaryVariant;
-  final Color secondary;
-  final Color secondaryVariant;
-  final Color surface;
-  final Color background;
-  final Color error;
-  final Color onPrimary;
-  final Color onSecondary;
-  final Color onSurface;
-  final Color onBackground;
-  final Color onError;
-  
-  // Chat-specific colors
-  final Color userMessageBackground;
-  final Color assistantMessageBackground;
-  final Color messageText;
-  final Color messageBorder;
-  final Color inputBackground;
-  final Color inputBorder;
-  final Color inputText;
-  
-  // UI-specific colors
-  final Color cardBackground;
-  final Color cardBorder;
-  final Color divider;
-  final Color shadow;
-  final Color overlay;
-  final Color disabled;
-  final Color hint;
-  
-  const AppColorScheme({
-    required this.primary,
-    required this.primaryVariant,
-    required this.secondary,
-    required this.secondaryVariant,
-    required this.surface,
-    required this.background,
-    required this.error,
-    required this.onPrimary,
-    required this.onSecondary,
-    required this.onSurface,
-    required this.onBackground,
-    required this.onError,
-    required this.userMessageBackground,
-    required this.assistantMessageBackground,
-    required this.messageText,
-    required this.messageBorder,
-    required this.inputBackground,
-    required this.inputBorder,
-    required this.inputText,
-    required this.cardBackground,
-    required this.cardBorder,
-    required this.divider,
-    required this.shadow,
-    required this.overlay,
-    required this.disabled,
-    required this.hint,
-  });
 }
 
 class ThemeService extends ChangeNotifier {
@@ -173,17 +113,33 @@ class ThemeService extends ChangeNotifier {
     );
   }
 
-  AppColorScheme _getColorSchemeForBrightness(Brightness brightness) => _lightColorScheme;
-
-  AppColorScheme _getCurrentColorScheme() => _lightColorScheme;
-
-  ThemeData get currentTheme {
-    return _buildThemeData(Brightness.light, _lightColorScheme);
+  AppColorScheme _getColorSchemeForBrightness(Brightness brightness) {
+    switch (_colorSchemeType) {
+      case ColorSchemeType.highContrast:
+        return brightness == Brightness.dark
+            ? AppThemeColors.darkHighContrast
+            : AppThemeColors.lightHighContrast;
+      case ColorSchemeType.custom:
+      case ColorSchemeType.standard:
+        return brightness == Brightness.dark
+            ? AppThemeColors.dark
+            : AppThemeColors.light;
+    }
   }
 
-  ThemeData get lightTheme => _buildThemeData(Brightness.light, _lightColorScheme);
+  AppColorScheme _getCurrentColorScheme() =>
+      _getColorSchemeForBrightness(_getEffectiveBrightness());
 
-  ThemeData get darkTheme => _buildThemeData(Brightness.light, _lightColorScheme);
+  ThemeData get currentTheme {
+    final brightness = _getEffectiveBrightness();
+    return _buildThemeData(brightness, _getColorSchemeForBrightness(brightness));
+  }
+
+  ThemeData get lightTheme =>
+      _buildThemeData(Brightness.light, AppThemeColors.light);
+
+  ThemeData get darkTheme =>
+      _buildThemeData(Brightness.dark, AppThemeColors.dark);
   
   ThemeData _buildThemeData(Brightness brightness, AppColorScheme colorScheme) {
     final isDark = brightness == Brightness.dark;
@@ -336,7 +292,7 @@ class ThemeService extends ChangeNotifier {
       // Snack bar
       snackBarTheme: SnackBarThemeData(
         backgroundColor: isDark ? Colors.grey[800] : Colors.grey[900],
-        contentTextStyle: TextStyle(color: Colors.white),
+        contentTextStyle: const TextStyle(color: Colors.white),
         shape: RoundedRectangleBorder(
           borderRadius: BorderRadius.circular(8),
         ),
@@ -344,124 +300,4 @@ class ThemeService extends ChangeNotifier {
       ),
     );
   }
-  
-  // Light color scheme
-  static const AppColorScheme _lightColorScheme = AppColorScheme(
-    primary: Color(0xFF6750A4),
-    primaryVariant: Color(0xFF4F378B),
-    secondary: Color(0xFF625B71),
-    secondaryVariant: Color(0xFF4A4458),
-    surface: Color(0xFFFFFBFE),
-    background: Color(0xFFFFFBFE),
-    error: Color(0xFFBA1A1A),
-    onPrimary: Color(0xFFFFFFFF),
-    onSecondary: Color(0xFFFFFFFF),
-    onSurface: Color(0xFF1C1B1F),
-    onBackground: Color(0xFF1C1B1F),
-    onError: Color(0xFFFFFFFF),
-    userMessageBackground: Color(0xFF6750A4),
-    assistantMessageBackground: Color(0xFFF3F0FF),
-    messageText: Color(0xFF1C1B1F),
-    messageBorder: Color(0xFFE7E0EC),
-    inputBackground: Color(0xFFF7F2FA),
-    inputBorder: Color(0xFFCAC4D0),
-    inputText: Color(0xFF1C1B1F),
-    cardBackground: Color(0xFFFFFBFE),
-    cardBorder: Color(0xFFE7E0EC),
-    divider: Color(0xFFE7E0EC),
-    shadow: Color(0x1F000000),
-    overlay: Color(0x66000000),
-    disabled: Color(0x61000000),
-    hint: Color(0x99000000),
-  );
-  
-  // Dark color scheme
-  static const AppColorScheme _darkColorScheme = AppColorScheme(
-    primary: Color(0xFFD0BCFF),
-    primaryVariant: Color(0xFF6750A4),
-    secondary: Color(0xFFCCC2DC),
-    secondaryVariant: Color(0xFF625B71),
-    surface: Color(0xFF1C1B1F),
-    background: Color(0xFF141218),
-    error: Color(0xFFFFB4AB),
-    onPrimary: Color(0xFF371E73),
-    onSecondary: Color(0xFF332D41),
-    onSurface: Color(0xFFE6E1E5),
-    onBackground: Color(0xFFE6E1E5),
-    onError: Color(0xFF690005),
-    userMessageBackground: Color(0xFF6750A4),
-    assistantMessageBackground: Color(0xFF2B2930),
-    messageText: Color(0xFFE6E1E5),
-    messageBorder: Color(0xFF49454F),
-    inputBackground: Color(0xFF2B2930),
-    inputBorder: Color(0xFF79747E),
-    inputText: Color(0xFFE6E1E5),
-    cardBackground: Color(0xFF1C1B1F),
-    cardBorder: Color(0xFF49454F),
-    divider: Color(0xFF49454F),
-    shadow: Color(0x3F000000),
-    overlay: Color(0x66000000),
-    disabled: Color(0x61FFFFFF),
-    hint: Color(0x99FFFFFF),
-  );
-  
-  // Light high contrast color scheme
-  static const AppColorScheme _lightHighContrastColorScheme = AppColorScheme(
-    primary: Color(0xFF000000),
-    primaryVariant: Color(0xFF000000),
-    secondary: Color(0xFF2E2E2E),
-    secondaryVariant: Color(0xFF1A1A1A),
-    surface: Color(0xFFFFFFFF),
-    background: Color(0xFFFFFFFF),
-    error: Color(0xFFD32F2F),
-    onPrimary: Color(0xFFFFFFFF),
-    onSecondary: Color(0xFFFFFFFF),
-    onSurface: Color(0xFF000000),
-    onBackground: Color(0xFF000000),
-    onError: Color(0xFFFFFFFF),
-    userMessageBackground: Color(0xFF000000),
-    assistantMessageBackground: Color(0xFFF5F5F5),
-    messageText: Color(0xFF000000),
-    messageBorder: Color(0xFF000000),
-    inputBackground: Color(0xFFFFFFFF),
-    inputBorder: Color(0xFF000000),
-    inputText: Color(0xFF000000),
-    cardBackground: Color(0xFFFFFFFF),
-    cardBorder: Color(0xFF000000),
-    divider: Color(0xFF000000),
-    shadow: Color(0x3F000000),
-    overlay: Color(0x80000000),
-    disabled: Color(0x80000000),
-    hint: Color(0x80000000),
-  );
-  
-  // Dark high contrast color scheme
-  static const AppColorScheme _darkHighContrastColorScheme = AppColorScheme(
-    primary: Color(0xFFFFFFFF),
-    primaryVariant: Color(0xFFFFFFFF),
-    secondary: Color(0xFFE0E0E0),
-    secondaryVariant: Color(0xFFCCCCCC),
-    surface: Color(0xFF000000),
-    background: Color(0xFF000000),
-    error: Color(0xFFFF5252),
-    onPrimary: Color(0xFF000000),
-    onSecondary: Color(0xFF000000),
-    onSurface: Color(0xFFFFFFFF),
-    onBackground: Color(0xFFFFFFFF),
-    onError: Color(0xFF000000),
-    userMessageBackground: Color(0xFFFFFFFF),
-    assistantMessageBackground: Color(0xFF1A1A1A),
-    messageText: Color(0xFFFFFFFF),
-    messageBorder: Color(0xFFFFFFFF),
-    inputBackground: Color(0xFF000000),
-    inputBorder: Color(0xFFFFFFFF),
-    inputText: Color(0xFFFFFFFF),
-    cardBackground: Color(0xFF000000),
-    cardBorder: Color(0xFFFFFFFF),
-    divider: Color(0xFFFFFFFF),
-    shadow: Color(0x3FFFFFFF),
-    overlay: Color(0x80FFFFFF),
-    disabled: Color(0x80FFFFFF),
-    hint: Color(0x80FFFFFF),
-  );
 }

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,0 +1,256 @@
+import 'package:flutter/material.dart';
+
+/// Foundational color tokens used across PocketLLM.
+///
+/// These values capture the product's brand, surfaces, feedback and
+/// chat-specific styling so that components can reference a single source of
+/// truth. Higher level theme configuration should compose these tokens instead
+/// of hard coding color values.
+class AppColorTokens {
+  AppColorTokens._();
+
+  // Brand colors
+  static const Color brandPrimary = Color(0xFF6750A4);
+  static const Color brandPrimaryVariant = Color(0xFF4F378B);
+  static const Color brandSecondary = Color(0xFF625B71);
+  static const Color brandSecondaryVariant = Color(0xFF4A4458);
+
+  // Light surfaces
+  static const Color surfaceLight = Color(0xFFFFFBFE);
+  static const Color backgroundLight = Color(0xFFFFFBFE);
+
+  // Dark surfaces
+  static const Color surfaceDark = Color(0xFF1C1B1F);
+  static const Color backgroundDark = Color(0xFF141218);
+
+  // Error states
+  static const Color errorLight = Color(0xFFBA1A1A);
+  static const Color errorDark = Color(0xFFFFB4AB);
+
+  // Foreground on light surfaces
+  static const Color textOnLight = Color(0xFF1C1B1F);
+  static const Color inverseTextOnLight = Color(0xFFFFFFFF);
+
+  // Foreground on dark surfaces
+  static const Color textOnDark = Color(0xFFE6E1E5);
+  static const Color inverseTextOnDark = Color(0xFF371E73);
+
+  // High contrast palettes
+  static const Color highContrastSurfaceLight = Color(0xFFFFFFFF);
+  static const Color highContrastSurfaceDark = Color(0xFF000000);
+  static const Color highContrastPrimaryLight = Color(0xFF000000);
+  static const Color highContrastPrimaryDark = Color(0xFFFFFFFF);
+  static const Color highContrastErrorLight = Color(0xFFD32F2F);
+  static const Color highContrastErrorDark = Color(0xFFFF5252);
+
+  // Chat specific tokens
+  static const Color chatUserMessage = Color(0xFF6750A4);
+  static const Color chatAssistantMessageLight = Color(0xFFF3F0FF);
+  static const Color chatAssistantMessageDark = Color(0xFF2B2930);
+
+  static const Color chatMessageBorderLight = Color(0xFFE7E0EC);
+  static const Color chatMessageBorderDark = Color(0xFF49454F);
+
+  static const Color inputBackgroundLight = Color(0xFFF7F2FA);
+  static const Color inputBackgroundDark = Color(0xFF2B2930);
+  static const Color inputBorderLight = Color(0xFFCAC4D0);
+  static const Color inputBorderDark = Color(0xFF79747E);
+
+  static const Color cardBorderLight = Color(0xFFE7E0EC);
+  static const Color cardBorderDark = Color(0xFF49454F);
+
+  static const Color overlay = Color(0x66000000);
+  static const Color shadowLight = Color(0x1F000000);
+  static const Color shadowDark = Color(0x3F000000);
+
+  static const Color disabledOnLight = Color(0x61000000);
+  static const Color disabledOnDark = Color(0x61FFFFFF);
+  static const Color hintOnLight = Color(0x99000000);
+  static const Color hintOnDark = Color(0x99FFFFFF);
+}
+
+/// Rich color definition for a particular application theme. Widgets can
+/// reference these strongly typed fields to keep color usage expressive.
+class AppColorScheme {
+  final Color primary;
+  final Color primaryVariant;
+  final Color secondary;
+  final Color secondaryVariant;
+  final Color surface;
+  final Color background;
+  final Color error;
+  final Color onPrimary;
+  final Color onSecondary;
+  final Color onSurface;
+  final Color onBackground;
+  final Color onError;
+
+  // Chat-specific colors
+  final Color userMessageBackground;
+  final Color assistantMessageBackground;
+  final Color messageText;
+  final Color messageBorder;
+  final Color inputBackground;
+  final Color inputBorder;
+  final Color inputText;
+
+  // UI-specific colors
+  final Color cardBackground;
+  final Color cardBorder;
+  final Color divider;
+  final Color shadow;
+  final Color overlay;
+  final Color disabled;
+  final Color hint;
+
+  const AppColorScheme({
+    required this.primary,
+    required this.primaryVariant,
+    required this.secondary,
+    required this.secondaryVariant,
+    required this.surface,
+    required this.background,
+    required this.error,
+    required this.onPrimary,
+    required this.onSecondary,
+    required this.onSurface,
+    required this.onBackground,
+    required this.onError,
+    required this.userMessageBackground,
+    required this.assistantMessageBackground,
+    required this.messageText,
+    required this.messageBorder,
+    required this.inputBackground,
+    required this.inputBorder,
+    required this.inputText,
+    required this.cardBackground,
+    required this.cardBorder,
+    required this.divider,
+    required this.shadow,
+    required this.overlay,
+    required this.disabled,
+    required this.hint,
+  });
+}
+
+/// Canonical color schemes that can be consumed by the [ThemeService] or any
+/// widget that needs direct access to the palette.
+class AppThemeColors {
+  AppThemeColors._();
+
+  static const AppColorScheme light = AppColorScheme(
+    primary: AppColorTokens.brandPrimary,
+    primaryVariant: AppColorTokens.brandPrimaryVariant,
+    secondary: AppColorTokens.brandSecondary,
+    secondaryVariant: AppColorTokens.brandSecondaryVariant,
+    surface: AppColorTokens.surfaceLight,
+    background: AppColorTokens.backgroundLight,
+    error: AppColorTokens.errorLight,
+    onPrimary: AppColorTokens.inverseTextOnLight,
+    onSecondary: AppColorTokens.inverseTextOnLight,
+    onSurface: AppColorTokens.textOnLight,
+    onBackground: AppColorTokens.textOnLight,
+    onError: AppColorTokens.inverseTextOnLight,
+    userMessageBackground: AppColorTokens.chatUserMessage,
+    assistantMessageBackground: AppColorTokens.chatAssistantMessageLight,
+    messageText: AppColorTokens.textOnLight,
+    messageBorder: AppColorTokens.chatMessageBorderLight,
+    inputBackground: AppColorTokens.inputBackgroundLight,
+    inputBorder: AppColorTokens.inputBorderLight,
+    inputText: AppColorTokens.textOnLight,
+    cardBackground: AppColorTokens.surfaceLight,
+    cardBorder: AppColorTokens.cardBorderLight,
+    divider: AppColorTokens.cardBorderLight,
+    shadow: AppColorTokens.shadowLight,
+    overlay: AppColorTokens.overlay,
+    disabled: AppColorTokens.disabledOnLight,
+    hint: AppColorTokens.hintOnLight,
+  );
+
+  static const AppColorScheme dark = AppColorScheme(
+    primary: AppColorTokens.brandPrimary,
+    primaryVariant: AppColorTokens.brandPrimaryVariant,
+    secondary: AppColorTokens.brandSecondary,
+    secondaryVariant: AppColorTokens.brandSecondaryVariant,
+    surface: AppColorTokens.surfaceDark,
+    background: AppColorTokens.backgroundDark,
+    error: AppColorTokens.errorDark,
+    onPrimary: AppColorTokens.inverseTextOnDark,
+    onSecondary: AppColorTokens.textOnDark,
+    onSurface: AppColorTokens.textOnDark,
+    onBackground: AppColorTokens.textOnDark,
+    onError: AppColorTokens.textOnDark,
+    userMessageBackground: AppColorTokens.chatUserMessage,
+    assistantMessageBackground: AppColorTokens.chatAssistantMessageDark,
+    messageText: AppColorTokens.textOnDark,
+    messageBorder: AppColorTokens.chatMessageBorderDark,
+    inputBackground: AppColorTokens.inputBackgroundDark,
+    inputBorder: AppColorTokens.inputBorderDark,
+    inputText: AppColorTokens.textOnDark,
+    cardBackground: AppColorTokens.surfaceDark,
+    cardBorder: AppColorTokens.cardBorderDark,
+    divider: AppColorTokens.cardBorderDark,
+    shadow: AppColorTokens.shadowDark,
+    overlay: AppColorTokens.overlay,
+    disabled: AppColorTokens.disabledOnDark,
+    hint: AppColorTokens.hintOnDark,
+  );
+
+  static const AppColorScheme lightHighContrast = AppColorScheme(
+    primary: AppColorTokens.highContrastPrimaryLight,
+    primaryVariant: AppColorTokens.highContrastPrimaryLight,
+    secondary: Color(0xFF2E2E2E),
+    secondaryVariant: Color(0xFF1A1A1A),
+    surface: AppColorTokens.highContrastSurfaceLight,
+    background: AppColorTokens.highContrastSurfaceLight,
+    error: AppColorTokens.highContrastErrorLight,
+    onPrimary: AppColorTokens.inverseTextOnLight,
+    onSecondary: AppColorTokens.inverseTextOnLight,
+    onSurface: AppColorTokens.highContrastPrimaryLight,
+    onBackground: AppColorTokens.highContrastPrimaryLight,
+    onError: AppColorTokens.inverseTextOnLight,
+    userMessageBackground: AppColorTokens.highContrastPrimaryLight,
+    assistantMessageBackground: Color(0xFFF5F5F5),
+    messageText: AppColorTokens.highContrastPrimaryLight,
+    messageBorder: AppColorTokens.highContrastPrimaryLight,
+    inputBackground: AppColorTokens.highContrastSurfaceLight,
+    inputBorder: AppColorTokens.highContrastPrimaryLight,
+    inputText: AppColorTokens.highContrastPrimaryLight,
+    cardBackground: AppColorTokens.highContrastSurfaceLight,
+    cardBorder: AppColorTokens.highContrastPrimaryLight,
+    divider: AppColorTokens.highContrastPrimaryLight,
+    shadow: AppColorTokens.shadowDark,
+    overlay: const Color(0x80000000),
+    disabled: const Color(0x80000000),
+    hint: const Color(0x80000000),
+  );
+
+  static const AppColorScheme darkHighContrast = AppColorScheme(
+    primary: AppColorTokens.highContrastPrimaryDark,
+    primaryVariant: AppColorTokens.highContrastPrimaryDark,
+    secondary: Color(0xFFE0E0E0),
+    secondaryVariant: Color(0xFFCCCCCC),
+    surface: AppColorTokens.highContrastSurfaceDark,
+    background: AppColorTokens.highContrastSurfaceDark,
+    error: AppColorTokens.highContrastErrorDark,
+    onPrimary: AppColorTokens.highContrastSurfaceDark,
+    onSecondary: AppColorTokens.highContrastSurfaceDark,
+    onSurface: AppColorTokens.highContrastPrimaryDark,
+    onBackground: AppColorTokens.highContrastPrimaryDark,
+    onError: AppColorTokens.highContrastSurfaceDark,
+    userMessageBackground: AppColorTokens.highContrastPrimaryDark,
+    assistantMessageBackground: const Color(0xFF1A1A1A),
+    messageText: AppColorTokens.highContrastPrimaryDark,
+    messageBorder: AppColorTokens.highContrastPrimaryDark,
+    inputBackground: AppColorTokens.highContrastSurfaceDark,
+    inputBorder: AppColorTokens.highContrastPrimaryDark,
+    inputText: AppColorTokens.highContrastPrimaryDark,
+    cardBackground: AppColorTokens.highContrastSurfaceDark,
+    cardBorder: AppColorTokens.highContrastPrimaryDark,
+    divider: AppColorTokens.highContrastPrimaryDark,
+    shadow: AppColorTokens.shadowDark,
+    overlay: const Color(0x80FFFFFF),
+    disabled: const Color(0x80FFFFFF),
+    hint: const Color(0x80FFFFFF),
+  );
+}


### PR DESCRIPTION
## Summary
- introduce reusable color tokens and canonical palettes for light, dark, and high-contrast themes
- update the theme service to consume the shared palettes for building Material themes
- document the new theme directory in the project structure guide

## Testing
- `dart format lib/services/theme_service.dart lib/theme/app_colors.dart` *(fails: command not found: dart)*

------
https://chatgpt.com/codex/tasks/task_e_68d4da44025c832d873430336a70f80b