### PR TITLE
Fix AppColorScheme imports for sidebar modules

### DIFF
--- a/lib/component/appbar/chat_history.dart
+++ b/lib/component/appbar/chat_history.dart
@@ -3,6 +3,7 @@ import 'package:intl/intl.dart';
 
 import '../../services/chat_history_service.dart';
 import '../../services/theme_service.dart';
+import '../../theme/app_colors.dart';
 import '../models.dart';
 
 class ChatHistory extends StatefulWidget {

--- a/lib/component/sidebar.dart
+++ b/lib/component/sidebar.dart
@@ -11,6 +11,7 @@ import '../pages/library_page.dart';
 import '../pages/settings_page.dart';
 import '../services/chat_history_service.dart';
 import '../services/theme_service.dart';
+import '../theme/app_colors.dart';
 
 class Sidebar extends StatefulWidget {
   final Function(String conversationId)? onConversationSelected;


### PR DESCRIPTION
## Summary
- import the AppColorScheme definition into Sidebar and ChatHistory widgets so their type annotations resolve

## Testing
- `flutter analyze` *(fails: flutter is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e259b430832d9e471e4ca59acfbf