### PR TITLE
Fix swagger routing and improve onboarding integration

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -20,6 +20,16 @@ http://localhost:8000/v1
 
 For production deployments, replace `localhost:8000` with your server address.
 
+Production demo:
+
+```
+https://pocket-llm-lemon.vercel.app/v1
+```
+
+Swagger UI is available locally at `http://localhost:8000/api/docs` (also aliased at `http://localhost:8000/docs`) and in the hosted demo at
+`https://pocket-llm-lemon.vercel.app/docs` (legacy path `https://pocket-llm-lemon.vercel.app/api/docs`) unless disabled via `ENABLE_SWAGGER_DOCS`. The root endpoint (`GET /`) echoes
+the active docs path for quick verification.
+
 ## 🔐 Authentication
 
 All protected endpoints require a valid JWT token in the `Authorization` header:
@@ -157,6 +167,62 @@ Update the authenticated user's profile information.
     "survey_completed": true,
     "created_at": "2023-10-27T10:00:00.000Z",
     "updated_at": "2023-10-27T11:00:00.000Z"
+  }
+}
+```
+
+### Complete Onboarding Survey
+
+**POST** `/users/profile/onboarding`
+
+Capture the user's onboarding answers, mark their profile as complete, and persist structured survey data.
+
+**Request Body:**
+```json
+{
+  "full_name": "Ada Lovelace",
+  "username": "adalovelace",
+  "bio": "Working on AI productivity workflows",
+  "date_of_birth": "1995-06-15",
+  "profession": "Software Engineer",
+  "heard_from": "Friend recommendation",
+  "avatar_url": "https://example.com/avatar.png",
+  "age": 28,
+  "onboarding": {
+    "primary_goal": "Improve daily productivity with AI assistance",
+    "interests": ["Productivity", "Coding"],
+    "experience_level": "Intermediate",
+    "usage_frequency": "Daily",
+    "other_notes": "Prefers concise answers and actionable steps."
+  }
+}
+```
+
+**Response:**
+```json
+{
+  "success": true,
+  "data": {
+    "id": "uuid",
+    "email": "adalovelace@example.com",
+    "full_name": "Ada Lovelace",
+    "username": "adalovelace",
+    "bio": "Working on AI productivity workflows",
+    "date_of_birth": "1995-06-15",
+    "profession": "Software Engineer",
+    "heard_from": "Friend recommendation",
+    "avatar_url": "https://example.com/avatar.png",
+    "survey_completed": true,
+    "age": 28,
+    "onboarding": {
+      "primary_goal": "Improve daily productivity with AI assistance",
+      "interests": ["Productivity", "Coding"],
+      "experience_level": "Intermediate",
+      "usage_frequency": "Daily",
+      "other_notes": "Prefers concise answers and actionable steps."
+    },
+    "created_at": "2023-10-27T10:00:00.000Z",
+    "updated_at": "2023-10-27T10:00:00.000Z"
   }
 }
 ```

--- a/docs/api-maintenance.md
+++ b/docs/api-maintenance.md
@@ -91,7 +91,12 @@ When updating the comprehensive API guide ([api-documentation.md](api-documentat
 
 The backend automatically generates Swagger documentation available at:
 ```
-http://localhost:8000/api/docs
+http://localhost:8000/api/docs (or http://localhost:8000/docs)
+```
+
+Production demo:
+```
+https://pocket-llm-lemon.vercel.app/docs (legacy path https://pocket-llm-lemon.vercel.app/api/docs)
 ```
 
 To view the latest documentation:

--- a/lib/services/backend_api_service.dart
+++ b/lib/services/backend_api_service.dart
@@ -163,6 +163,8 @@ class BackendApiService {
     ];
 
     const builtInPrimaryCandidates = [
+      'http://localhost:8000',
+      'http://127.0.0.1:8000',
       'https://pocket-llm-lemon.vercel.app',
       'https://pocketllm.onrender.com',
     ];
@@ -190,7 +192,11 @@ class BackendApiService {
 
     urls.sort((a, b) {
       int weight(String url) {
-        if (url.contains('pocket-llm-lemon.vercel.app')) {
+        final lower = url.toLowerCase();
+        if (lower.contains('localhost') || lower.contains('127.0.0.1')) {
+          return -1;
+        }
+        if (lower.contains('pocket-llm-lemon.vercel.app')) {
           return 0;
         }
         if (url.startsWith('https://')) {

--- a/pocketllm-backend/POSTMAN_API_GUIDE.md
+++ b/pocketllm-backend/POSTMAN_API_GUIDE.md
@@ -5,6 +5,12 @@
 http://localhost:8000/v1
 ```
 
+For the hosted demo deployment you can target:
+
+```
+https://pocket-llm-lemon.vercel.app/v1
+```
+
 ## 🚀 Getting Started
 
 Follow these steps to prepare the NestJS backend before exercising the API collection:
@@ -23,9 +29,10 @@ Follow these steps to prepare the NestJS backend before exercising the API colle
    ```bash
    npm run start:dev
    ```
-   The REST API will be available at `http://localhost:8000/v1` and Swagger documentation at `http://localhost:8000/api/docs`.
+   The REST API will be available at `http://localhost:8000/v1` and Swagger documentation at `http://localhost:8000/api/docs` (aliased at `http://localhost:8000/docs`).
+   In production (Vercel demo) the docs are published at `https://pocket-llm-lemon.vercel.app/docs` (legacy path `https://pocket-llm-lemon.vercel.app/api/docs`).
 4. **Authenticate requests**
-   Use `POST /v1/auth/signin` to obtain an access token and send it in the `Authorization: Bearer <token>` header when calling protected routes. The Users, Chats, and Jobs controllers are guarded by the Supabase JWT so every request must include a valid token.
+   Use `POST /v1/auth/signin` to obtain an access token and send it in the `Authorization: Bearer <token>` header when calling protected routes. The Users, Chats, and Jobs controllers are guarded by the Supabase JWT so every request must include a valid token. You can always call `GET /v1` to verify routing and to see the currently active documentation links exposed by the server.
 
 I've created a comprehensive API documentation guide for Postman testing. Let me create a summary of what was accomplished:
 

--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -122,8 +122,9 @@ npm run start:debug
 ```
 
 The server will start on `http://localhost:8000` with:
-- 📚 API Documentation: `http://localhost:8000/api/docs` (configurable via `ENABLE_SWAGGER_DOCS` / `SWAGGER_DOCS_PATH`)
+- 📚 API Documentation: `http://localhost:8000/api/docs` (also available at `http://localhost:8000/docs`; configurable via `ENABLE_SWAGGER_DOCS` / `SWAGGER_DOCS_PATH`)
 - 🔗 API Base URL: `http://localhost:8000/v1`
+- 🌐 Production docs (Vercel demo): `https://pocket-llm-lemon.vercel.app/docs` (legacy path `https://pocket-llm-lemon.vercel.app/api/docs` continues to work)
 
 ## ☁️ Deploying to Vercel
 
@@ -156,14 +157,19 @@ After Vercel finishes building:
 
 1. Visit `https://<your-vercel-domain>/` – you should see a JSON payload confirming that the API is running and that all endpoints live under `/v1`.
 2. Visit `https://<your-vercel-domain>/health` to perform a lightweight health check that Vercel can use for monitoring.
-3. Call one of the actual API routes such as `https://<your-vercel-domain>/v1/auth/signin` to confirm that routing (and the `/v1` prefix) works as expected.
+3. Visit `https://<your-vercel-domain>/docs` (or the legacy `https://<your-vercel-domain>/api/docs`) to confirm that Swagger UI is available (unless you explicitly disabled it via `ENABLE_SWAGGER_DOCS=false`).
+4. Call one of the actual API routes such as `https://<your-vercel-domain>/v1/auth/signin` to confirm that routing (and the `/v1` prefix) works as expected.
 
 If you encounter a 404, double-check that the project root is set to `pocketllm-backend` and that the output directory is left blank. Setting an output directory forces Vercel to treat the build as a static site and bypass the serverless handler, which results in the `404: NOT_FOUND` error.
 
 ## 📖 API Documentation
 
 The API is fully documented with Swagger/OpenAPI. Once the server is running, visit:
-`http://localhost:8000/api/docs`
+
+- Local: `http://localhost:8000/api/docs` (also `http://localhost:8000/docs`)
+- Production demo: `https://pocket-llm-lemon.vercel.app/docs` (legacy path `https://pocket-llm-lemon.vercel.app/api/docs`)
+
+The root endpoint (`GET /`) echoes the active documentation path so you can verify the configuration quickly.
 
 ### Key Endpoints
 
@@ -182,7 +188,7 @@ by the Chats and Jobs controllers so every user-scoped route enforces authentica
 
 - `GET /v1/users/profile` – Fetches the current user's profile row from the `profiles` table.
 - `PUT /v1/users/profile` – Updates the authenticated user's profile data while handling duplicate usernames.
-- `POST /v1/users/profile/onboarding` – Captures onboarding responses (age, goals, interests) and marks the profile as survey complete.
+- `POST /v1/users/profile/onboarding` – Captures onboarding responses (age, goals, interests, experience level, usage frequency, additional notes) and marks the profile as survey complete.
 - `DELETE /v1/users/profile` – Permanently removes the Supabase user and cascades the related profile record.
 
 The `UsersService` performs an additional user ID check and returns a `401 Unauthorized` response when the guard is bypassed or

--- a/pocketllm-backend/src/app.controller.ts
+++ b/pocketllm-backend/src/app.controller.ts
@@ -1,13 +1,22 @@
 import { Controller, Get } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
 
 @Controller()
 export class AppController {
+  constructor(private readonly configService: ConfigService) {}
+
   @Get()
   getRoot() {
+    const apiPrefix = this.configService.get<string>('app.api.prefix') ?? 'v1';
+    const docsConfig = this.configService.get<{ enabled?: boolean; path?: string }>('app.docs');
+    const docsEnabled = docsConfig?.enabled !== false;
+    const docsPath = docsEnabled ? this.resolveDocsPath(docsConfig?.path) : null;
+
     return {
       status: 'ok',
-      message: 'PocketLLM backend is running. All REST endpoints are available under the /v1 prefix.',
-      docs: '/api/docs',
+      message: `PocketLLM backend is running. All REST endpoints are available under the /${apiPrefix} prefix.`,
+      docs: docsPath,
+      docsAliases: docsEnabled ? this.resolveDocsAliases(docsConfig?.path) : [],
       health: '/health',
     };
   }
@@ -18,5 +27,26 @@ export class AppController {
       status: 'ok',
       timestamp: new Date().toISOString(),
     };
+  }
+
+  private resolveDocsPath(path?: string | null): string {
+    const sanitized = (path ?? 'api/docs').trim().replace(/^\/+|\/+$/g, '');
+    return `/${sanitized.length > 0 ? sanitized : 'api/docs'}`;
+  }
+
+  private resolveDocsAliases(path?: string | null): string[] {
+    const primary = this.resolveDocsPath(path);
+    const normalized = primary.replace(/^\/+|\/+$/g, '');
+
+    if (!normalized.toLowerCase().startsWith('api/')) {
+      return [];
+    }
+
+    const alias = normalized.substring(4).replace(/^\/+/, '');
+    if (!alias) {
+      return [];
+    }
+
+    return [`/${alias}`];
   }
 }

--- a/pocketllm-backend/src/main.ts
+++ b/pocketllm-backend/src/main.ts
@@ -1,18 +1,122 @@
+import { randomUUID } from 'crypto';
 import { NestFactory } from '@nestjs/core';
-import { RequestMethod, ValidationPipe } from '@nestjs/common';
+import { RequestMethod, ValidationPipe, type INestApplication } from '@nestjs/common';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { ConfigService } from '@nestjs/config';
 import { AppModule } from './app.module';
 
+type DocsRouteInfo = {
+  primary: string;
+  aliases: string[];
+};
+
+function normalizeDocsPath(path?: string | null): string {
+  if (!path) {
+    return 'api/docs';
+  }
+
+  const trimmed = path.trim().replace(/^\/+|\/+$/g, '');
+  return trimmed.length > 0 ? trimmed : 'api/docs';
+}
+
+function buildDocsRoutes(path?: string | null): DocsRouteInfo {
+  const normalized = normalizeDocsPath(path);
+  const routes = new Set<string>();
+
+  const sanitized = normalized.replace(/^\/+|\/+$/g, '');
+  const primary = sanitized.length > 0 ? sanitized : 'api/docs';
+  routes.add(primary);
+
+  // Vercel treats the `/api/*` namespace specially. Serving the docs from
+  // an additional `/docs` path avoids collisions with function routing while
+  // keeping backwards compatibility for local development.
+  if (primary.toLowerCase().startsWith('api/')) {
+    const alias = primary.substring(4).replace(/^\/+/, '');
+    if (alias.length > 0) {
+      routes.add(alias);
+    }
+  }
+
+  return {
+    primary,
+    aliases: Array.from(routes).filter((route) => route !== primary),
+  };
+}
+
+function registerDocsEndpoints(app: INestApplication, docsRouteInfo: DocsRouteInfo) {
+  const config = new DocumentBuilder()
+    .setTitle('PocketLLM API')
+    .setDescription('Backend API for PocketLLM - AI Chat Application')
+    .setVersion('1.0.0')
+    .addBearerAuth()
+    .addTag('Authentication', 'User authentication endpoints')
+    .addTag('Users', 'User profile management')
+    .addTag('Chats', 'Chat and conversation management')
+    .addTag('Jobs', 'Background job management')
+    .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  const swaggerOptions = {
+    swaggerOptions: {
+      persistAuthorization: true,
+    },
+    customSiteTitle: 'PocketLLM API Docs',
+  } as const;
+
+  const docsRoutes = [docsRouteInfo.primary, ...docsRouteInfo.aliases];
+  docsRoutes.forEach((route) => {
+    SwaggerModule.setup(route, app, document, swaggerOptions);
+  });
+}
+
+function registerApiPrefixLanding(
+  app: INestApplication,
+  apiPrefix: string,
+  docsRouteInfo: DocsRouteInfo | null,
+) {
+  const httpAdapter = app.getHttpAdapter();
+  const instance = httpAdapter?.getInstance?.();
+  if (!instance || typeof instance.get !== 'function') {
+    return;
+  }
+
+  const docsLinks = docsRouteInfo
+    ? [docsRouteInfo.primary, ...docsRouteInfo.aliases].map((route) => `/${route}`)
+    : [];
+
+  instance.get(`/${apiPrefix}`, (request, response) => {
+    const startedAt = Date.now();
+    const requestId = (request as Record<string, any>)['requestId'] ?? randomUUID();
+    (request as Record<string, any>)['requestId'] = requestId;
+
+    response.json({
+      success: true,
+      data: {
+        message: `PocketLLM API root. Append endpoint paths such as /${apiPrefix}/auth/signin.`,
+        docs: docsLinks,
+        health: '/health',
+      },
+      error: null,
+      metadata: {
+        timestamp: new Date().toISOString(),
+        requestId,
+        processingTime: parseFloat((Date.now() - startedAt).toFixed(2)),
+      },
+    });
+  });
+}
+
 // Export the NestJS application instance for Vercel
 export async function createApp() {
   const app = await NestFactory.create(AppModule);
-  
+
   const configService = app.get(ConfigService);
   const port = configService.get<number>('app.port', 8000);
   const apiPrefix = configService.get<string>('app.api.prefix', 'v1');
   const corsOrigin = configService.get<string>('app.cors.origin', '*');
   const docsConfig = configService.get<{ enabled?: boolean; path?: string }>('app.docs');
+  const docsEnabled = docsConfig?.enabled !== false;
+  const docsRouteInfo = docsEnabled ? buildDocsRoutes(docsConfig?.path) : null;
 
   // Enable CORS
   app.enableCors({
@@ -23,11 +127,24 @@ export async function createApp() {
   });
 
   // Set global prefix for all routes
+  const globalPrefixExclusions: Array<string | { path: string; method: RequestMethod }> = [
+    { path: '/', method: RequestMethod.GET },
+    { path: '/health', method: RequestMethod.GET },
+  ];
+
+  if (docsRouteInfo) {
+    const allDocsRoutes = new Set<string>([docsRouteInfo.primary, ...docsRouteInfo.aliases]);
+    allDocsRoutes.forEach((route) => {
+      const normalized = route.replace(/^\/+|\/+$/g, '');
+      if (normalized.length === 0) {
+        return;
+      }
+      globalPrefixExclusions.push(normalized, `${normalized}/(.*)`, `${normalized.replace(/\/+$/, '')}-json`);
+    });
+  }
+
   app.setGlobalPrefix(apiPrefix, {
-    exclude: [
-      { path: '/', method: RequestMethod.GET },
-      { path: '/health', method: RequestMethod.GET },
-    ],
+    exclude: globalPrefixExclusions,
   });
 
   // Global validation pipe
@@ -43,26 +160,11 @@ export async function createApp() {
   );
 
   // Swagger documentation setup (configurable for all environments)
-  if (docsConfig?.enabled !== false) {
-    const config = new DocumentBuilder()
-      .setTitle('PocketLLM API')
-      .setDescription('Backend API for PocketLLM - AI Chat Application')
-      .setVersion('1.0.0')
-      .addBearerAuth()
-      .addTag('Authentication', 'User authentication endpoints')
-      .addTag('Users', 'User profile management')
-      .addTag('Chats', 'Chat and conversation management')
-      .addTag('Jobs', 'Background job management')
-      .build();
-
-    const document = SwaggerModule.createDocument(app, config);
-    const docsPath = docsConfig?.path || 'api/docs';
-    SwaggerModule.setup(docsPath, app, document, {
-      swaggerOptions: {
-        persistAuthorization: true,
-      },
-    });
+  if (docsRouteInfo) {
+    registerDocsEndpoints(app, docsRouteInfo);
   }
+
+  registerApiPrefixLanding(app, apiPrefix, docsRouteInfo);
 
   return app;
 }
@@ -72,16 +174,21 @@ async function bootstrap() {
   const app = await createApp();
   const configService = app.get(ConfigService);
   const docsConfig = configService.get<{ enabled?: boolean; path?: string }>('app.docs');
+  const apiPrefix = configService.get<string>('app.api.prefix', 'v1');
   const port = configService.get<number>('app.port', 8000);
-  
+  const docsEnabled = docsConfig?.enabled !== false;
+  const docsRouteInfo = docsEnabled ? buildDocsRoutes(docsConfig?.path) : null;
+
   await app.listen(port);
-  
+
   console.log(`🚀 PocketLLM Backend is running on: http://localhost:${port}`);
-  if (docsConfig?.enabled !== false) {
-    const docsPath = docsConfig?.path || 'api/docs';
-    console.log(`📚 API Documentation: http://localhost:${port}/${docsPath}`);
+  if (docsRouteInfo) {
+    const docsTargets = [docsRouteInfo.primary, ...docsRouteInfo.aliases]
+      .map((route) => `http://localhost:${port}/${route}`)
+      .join(', ');
+    console.log(`📚 API Documentation: ${docsTargets}`);
   }
-  console.log(`🔗 API Base URL: http://localhost:${port}/v1`);
+  console.log(`🔗 API Base URL: http://localhost:${port}/${apiPrefix}`);
 }
 
 // For Vercel deployment


### PR DESCRIPTION
## Summary
- expose Swagger UI on both `/api/docs` and `/docs`, add a JSON landing response for `/v1`, and keep documentation paths visible via the root controller
- prefer local backends inside the Flutter client so profile and onboarding calls use the developer instance when available
- refresh the README, Postman guide, and internal docs with the new documentation URLs and troubleshooting tips

## Testing
- Attempted `npm run build` *(fails: Nest CLI missing because npm install could not complete in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4e92e1814832d836fc9fb441ac001