### PR TITLE
Revamp user onboarding survey flow

### DIFF
--- a/lib/component/survey/survey_option_tile.dart
+++ b/lib/component/survey/survey_option_tile.dart
@@ -1,0 +1,71 @@
+import 'package:flutter/material.dart';
+
+class SurveyOptionTile extends StatelessWidget {
+  final String label;
+  final bool selected;
+  final VoidCallback onTap;
+
+  const SurveyOptionTile({
+    super.key,
+    required this.label,
+    required this.selected,
+    required this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isSelected = selected;
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: Container(
+        padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(16),
+          color: isSelected ? theme.colorScheme.primary.withOpacity(0.08) : Colors.white,
+          border: Border.all(
+            color: isSelected ? theme.colorScheme.primary : Colors.grey.shade300,
+            width: isSelected ? 1.5 : 1,
+          ),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: Text(
+                label,
+                style: theme.textTheme.bodyLarge?.copyWith(
+                  color: isSelected ? theme.colorScheme.primary : Colors.black87,
+                  fontWeight: isSelected ? FontWeight.w600 : FontWeight.w500,
+                ),
+              ),
+            ),
+            AnimatedContainer(
+              duration: const Duration(milliseconds: 200),
+              width: 20,
+              height: 20,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(
+                  color: isSelected ? theme.colorScheme.primary : Colors.grey.shade400,
+                  width: 2,
+                ),
+              ),
+              child: AnimatedScale(
+                duration: const Duration(milliseconds: 200),
+                scale: isSelected ? 1 : 0,
+                child: Container(
+                  margin: const EdgeInsets.all(3),
+                  decoration: BoxDecoration(
+                    color: theme.colorScheme.primary,
+                    shape: BoxShape.circle,
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/component/survey/survey_progress_indicator.dart
+++ b/lib/component/survey/survey_progress_indicator.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+
+class SurveyProgressIndicator extends StatelessWidget {
+  final int totalSteps;
+  final int currentStep;
+
+  const SurveyProgressIndicator({
+    super.key,
+    required this.totalSteps,
+    required this.currentStep,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+      children: List.generate(totalSteps, (index) {
+        final stepNumber = index + 1;
+        final isActive = index == currentStep;
+        final isCompleted = index < currentStep;
+        final Color backgroundColor;
+        final Color textColor;
+
+        if (isActive) {
+          backgroundColor = theme.colorScheme.primary;
+          textColor = Colors.white;
+        } else if (isCompleted) {
+          backgroundColor = theme.colorScheme.primary.withOpacity(0.12);
+          textColor = theme.colorScheme.primary;
+        } else {
+          backgroundColor = Colors.grey.shade200;
+          textColor = Colors.grey.shade500;
+        }
+
+        return Container(
+          width: 32,
+          height: 32,
+          alignment: Alignment.center,
+          decoration: BoxDecoration(
+            color: backgroundColor,
+            shape: BoxShape.circle,
+          ),
+          child: Text(
+            '$stepNumber',
+            style: theme.textTheme.bodyMedium?.copyWith(
+              color: textColor,
+              fontWeight: isActive ? FontWeight.w600 : FontWeight.w500,
+            ),
+          ),
+        );
+      }),
+    );
+  }
+}

--- a/lib/models/survey_model.dart
+++ b/lib/models/survey_model.dart
@@ -1,0 +1,53 @@
+import 'package:equatable/equatable.dart';
+
+class SurveyQuestion extends Equatable {
+  final String id;
+  final String title;
+  final String? subtitle;
+  final List<SurveyOption> options;
+  final bool isMultiSelect;
+
+  const SurveyQuestion({
+    required this.id,
+    required this.title,
+    this.subtitle,
+    required this.options,
+    this.isMultiSelect = false,
+  });
+
+  @override
+  List<Object?> get props => [id, title, subtitle, options, isMultiSelect];
+}
+
+class SurveyOption extends Equatable {
+  final String id;
+  final String label;
+
+  const SurveyOption({
+    required this.id,
+    required this.label,
+  });
+
+  @override
+  List<Object?> get props => [id, label];
+}
+
+class SurveyResponse extends Equatable {
+  final Map<String, dynamic> answers;
+
+  const SurveyResponse({
+    required this.answers,
+  });
+
+  SurveyResponse copyWithAnswer(String questionId, dynamic value) {
+    final updated = Map<String, dynamic>.from(answers)..[questionId] = value;
+    return SurveyResponse(answers: updated);
+  }
+
+  bool get isEmpty => answers.isEmpty;
+
+  Map<String, dynamic> toJson() => Map<String, dynamic>.from(answers);
+
+  @override
+  List<Object?> get props => [answers];
+}

--- a/lib/pages/auth/user_survey_page.dart
+++ b/lib/pages/auth/user_survey_page.dart
@@ -1,11 +1,11 @@
-import 'dart:io';
-import 'dart:math' as math;
-
 import 'package:flutter/material.dart';
-import 'package:image_picker/image_picker.dart';
 import 'package:provider/provider.dart';
 
+import '../../component/survey/survey_option_tile.dart';
+import '../../component/survey/survey_progress_indicator.dart';
+import '../../models/survey_model.dart';
 import '../../services/auth_state.dart';
+import '../../services/survey_service.dart';
 
 class UserSurveyPage extends StatefulWidget {
   final VoidCallback onComplete;
@@ -19,25 +19,12 @@ class UserSurveyPage extends StatefulWidget {
   State<UserSurveyPage> createState() => _UserSurveyPageState();
 }
 
-class _UserSurveyPageState extends State<UserSurveyPage> with SingleTickerProviderStateMixin {
+class _UserSurveyPageState extends State<UserSurveyPage> {
   final _formKey = GlobalKey<FormState>();
   final _nameController = TextEditingController();
   final _usernameController = TextEditingController();
   final _bioController = TextEditingController();
-  DateTime? _selectedDate;
-  String? _selectedProfession;
-  String? _selectedSource;
-  File? _profileImage;
-  String? _selectedAvatar;
-  bool _isSubmitting = false;
-  String? _errorMessage;
-  double _progressValue = 0.0;
-
-  AnimationController? _controller;
-  Animation<double>? _fadeAnimation;
-  Animation<Offset>? _slideAnimation;
-
-  final List<String> _professions = [
+  final List<String> _professions = const [
     'Student',
     'Developer',
     'Designer',
@@ -45,143 +32,155 @@ class _UserSurveyPageState extends State<UserSurveyPage> with SingleTickerProvid
     'Data Scientist',
     'Researcher',
     'Educator',
-    'Other'
+    'Other',
   ];
-
-  final List<String> _sources = [
+  final List<String> _sources = const [
     'Search Engine',
     'Social Media',
     'Friend/Colleague',
     'Advertisement',
     'App Store',
-    'Other'
+    'Other',
   ];
 
-  final List<String> _avatarOptions = [
-    'assets/avatar1.jpg',
-    'assets/avatar2.jpg',
-  ];
+  late final List<SurveyQuestion> _questions;
+
+  final Map<String, dynamic> _answers = {};
+  int _currentStep = 0;
+  bool _isSubmitting = false;
+  String? _errorMessage;
+  String? _selectedProfession;
+  String? _selectedSource;
 
   @override
   void initState() {
     super.initState();
-    final random = math.Random();
-    _selectedAvatar = _avatarOptions[random.nextInt(_avatarOptions.length)];
-    _updateProgress();
-
-    _controller = AnimationController(
-      vsync: this,
-      duration: const Duration(milliseconds: 900),
-    );
-    _fadeAnimation = CurvedAnimation(parent: _controller!, curve: Curves.easeInOut);
-    _slideAnimation = Tween<Offset>(begin: const Offset(0.0, 0.25), end: Offset.zero)
-        .animate(CurvedAnimation(parent: _controller!, curve: Curves.easeInOut));
-    _controller!.forward();
+    _questions = [
+      const SurveyQuestion(
+        id: 'age_range',
+        title: 'Answer some questions about yourself to get started.',
+        subtitle: 'What is your age range?',
+        options: [
+          SurveyOption(id: 'under_18', label: 'Under 18'),
+          SurveyOption(id: '18_34', label: '18-34'),
+          SurveyOption(id: '35_54', label: '35-54'),
+          SurveyOption(id: '55_plus', label: '55 or over'),
+        ],
+      ),
+      const SurveyQuestion(
+        id: 'education_level',
+        title: 'Answer some questions about yourself to get started.',
+        subtitle: 'What is your highest level of education completed?',
+        options: [
+          SurveyOption(id: 'high_school', label: 'High school or less'),
+          SurveyOption(id: 'some_college', label: 'Some college or vocational training'),
+          SurveyOption(id: 'bachelors', label: "Bachelor's degree"),
+          SurveyOption(id: 'graduate', label: "Graduate degree"),
+        ],
+      ),
+      const SurveyQuestion(
+        id: 'gender',
+        title: 'Answer some questions about yourself to get started.',
+        subtitle: 'What is your gender?',
+        options: [
+          SurveyOption(id: 'male', label: 'Male'),
+          SurveyOption(id: 'female', label: 'Female'),
+          SurveyOption(id: 'other', label: 'Rather not say'),
+        ],
+      ),
+      const SurveyQuestion(
+        id: 'ethnicity',
+        title: 'Answer some questions about yourself to get started.',
+        subtitle: 'What is your ethnicity or race?',
+        options: [
+          SurveyOption(id: 'white', label: 'Caucasian/White'),
+          SurveyOption(id: 'black', label: 'African American/Black'),
+          SurveyOption(id: 'latinx', label: 'Hispanic/Latinx'),
+          SurveyOption(id: 'asian', label: 'Asian/Asian American'),
+          SurveyOption(id: 'other', label: 'Other / Prefer not to say'),
+        ],
+      ),
+    ];
   }
 
   @override
   void dispose() {
-    _controller?.dispose();
     _nameController.dispose();
     _usernameController.dispose();
     _bioController.dispose();
     super.dispose();
   }
 
-  void _updateProgress() {
-    double progress = 0.0;
-    if (_nameController.text.isNotEmpty) progress += 0.17;
-    if (_usernameController.text.isNotEmpty) progress += 0.17;
-    if (_selectedDate != null) progress += 0.17;
-    if (_selectedProfession != null) progress += 0.17;
-    if (_selectedSource != null) progress += 0.16;
-    if (_profileImage != null || _selectedAvatar != null) progress += 0.16;
+  int get _totalSteps => _questions.length + 1;
 
+  bool get _isProfileStep => _currentStep >= _questions.length;
+
+  void _handleExit() {
+    Navigator.of(context).maybePop();
+  }
+
+  void _handleBack() {
+    if (_currentStep == 0) {
+      _handleExit();
+      return;
+    }
     setState(() {
-      _progressValue = progress.clamp(0.0, 1.0);
+      _errorMessage = null;
+      _currentStep -= 1;
     });
   }
 
-  Future<void> _pickImage() async {
-    try {
-      final picker = ImagePicker();
-      final image = await picker.pickImage(source: ImageSource.gallery, maxHeight: 600, maxWidth: 600);
-      if (image != null) {
-        setState(() {
-          _profileImage = File(image.path);
-          _selectedAvatar = null;
-          _updateProgress();
-        });
-      }
-    } catch (e) {
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text('Error selecting image: $e')),
-      );
+  void _handleNext() {
+    if (_isProfileStep) {
+      _submit();
+      return;
     }
-  }
 
-  Future<void> _selectDate(BuildContext context) async {
-    final picked = await showDatePicker(
-      context: context,
-      initialDate: DateTime.now().subtract(const Duration(days: 365 * 18)),
-      firstDate: DateTime(1950),
-      lastDate: DateTime.now(),
-      builder: (context, child) {
-        return Theme(
-          data: ThemeData.light().copyWith(
-            colorScheme: const ColorScheme.light(
-              primary: Color(0xFF6D28D9),
-              onPrimary: Colors.white,
-            ),
-          ),
-          child: child!,
-        );
-      },
-    );
-
-    if (picked != null) {
+    final question = _questions[_currentStep];
+    final answer = _answers[question.id];
+    if (answer == null || (answer is List && answer.isEmpty)) {
       setState(() {
-        _selectedDate = picked;
-        _updateProgress();
+        _errorMessage = 'Please select an option to continue.';
       });
+      return;
     }
+
+    setState(() {
+      _errorMessage = null;
+      _currentStep += 1;
+    });
   }
 
-  Future<void> _saveProfileAndComplete() async {
+  Future<void> _submit() async {
     if (!(_formKey.currentState?.validate() ?? false)) {
       return;
     }
 
     final authState = context.read<AuthState>();
+    final surveyService = SurveyService(authState);
+    final onboardingAnswers = {
+      'age_range': _answers['age_range'],
+      'education_level': _answers['education_level'],
+      'gender': _answers['gender'],
+      'ethnicity': _answers['ethnicity'],
+    }..removeWhere((key, value) => value == null);
+
     try {
       setState(() {
         _isSubmitting = true;
         _errorMessage = null;
       });
 
-      String? avatarUrl = _selectedAvatar;
-      if (_profileImage != null) {
-        try {
-          avatarUrl = await authState.uploadProfileImage(_profileImage!);
-        } catch (e) {
-          avatarUrl = null;
-          ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(content: Text('Unable to upload profile image: $e')),
-          );
-        }
-      }
-
-      await authState.completeProfile(
-        fullName: _nameController.text.trim(),
-        username: _usernameController.text.trim(),
-        bio: _bioController.text.trim().isEmpty ? null : _bioController.text.trim(),
-        dateOfBirth: _selectedDate,
-        profession: _selectedProfession,
-        heardFrom: _selectedSource,
-        avatarUrl: avatarUrl,
+      await surveyService.submitSurvey(
+        SurveyPayload(
+          fullName: _nameController.text.trim(),
+          username: _usernameController.text.trim(),
+          bio: _bioController.text.trim().isEmpty ? null : _bioController.text.trim(),
+          profession: _selectedProfession,
+          heardFrom: _selectedSource,
+          onboarding: onboardingAnswers,
+        ),
       );
-
-      await authState.refreshProfile();
 
       if (!mounted) return;
       setState(() {
@@ -190,208 +189,241 @@ class _UserSurveyPageState extends State<UserSurveyPage> with SingleTickerProvid
 
       ScaffoldMessenger.of(context).showSnackBar(
         const SnackBar(
-          content: Text('Profile completed successfully!'),
+          content: Text('Thanks! Your responses have been saved.'),
           backgroundColor: Color(0xFF6D28D9),
         ),
       );
 
       widget.onComplete();
       if (Navigator.canPop(context)) {
-        Navigator.pop(context);
+        Navigator.of(context).pop();
       }
     } catch (e) {
       if (!mounted) return;
       setState(() {
         _isSubmitting = false;
-        _errorMessage = 'Error saving profile: $e';
+        _errorMessage = 'Error saving survey: $e';
       });
-      ScaffoldMessenger.of(context).showSnackBar(
-        SnackBar(content: Text(_errorMessage ?? 'An error occurred'), backgroundColor: Colors.redAccent),
-      );
     }
   }
 
-  InputDecoration _buildInputDecoration(String label) {
-    return InputDecoration(
-      labelText: label,
-      border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+  Widget _buildQuestionStep(SurveyQuestion question, ThemeData theme) {
+    final selectedValue = _answers[question.id];
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          question.title,
+          style: theme.textTheme.headlineSmall?.copyWith(
+            fontWeight: FontWeight.bold,
+            color: Colors.black,
+          ),
+        ),
+        const SizedBox(height: 16),
+        if (question.subtitle != null)
+          Text(
+            question.subtitle!,
+            style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+              color: Colors.black,
+            ),
+          ),
+        const SizedBox(height: 24),
+        ...question.options.map(
+          (option) => Padding(
+            padding: const EdgeInsets.only(bottom: 12),
+            child: SurveyOptionTile(
+              label: option.label,
+              selected: selectedValue == option.id,
+              onTap: () {
+                setState(() {
+                  _answers[question.id] = option.id;
+                  _errorMessage = null;
+                });
+              },
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildProfileStep(ThemeData theme) {
+    return Form(
+      key: _formKey,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            'Complete your profile',
+            style: theme.textTheme.headlineSmall?.copyWith(
+              fontWeight: FontWeight.bold,
+              color: Colors.black,
+            ),
+          ),
+          const SizedBox(height: 12),
+          Text(
+            'Add a few more details so we can personalize your experience.',
+            style: theme.textTheme.bodyMedium?.copyWith(color: Colors.black54),
+          ),
+          const SizedBox(height: 24),
+          TextFormField(
+            controller: _nameController,
+            decoration: const InputDecoration(
+              labelText: 'Full Name',
+              border: OutlineInputBorder(),
+            ),
+            validator: (value) {
+              if (value == null || value.trim().isEmpty) {
+                return 'Full name is required';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: _usernameController,
+            decoration: const InputDecoration(
+              labelText: 'Username',
+              border: OutlineInputBorder(),
+            ),
+            validator: (value) {
+              if (value == null || value.trim().length < 3) {
+                return 'Username must be at least 3 characters';
+              }
+              return null;
+            },
+          ),
+          const SizedBox(height: 16),
+          TextFormField(
+            controller: _bioController,
+            maxLines: 3,
+            decoration: const InputDecoration(
+              labelText: 'Bio (optional)',
+              border: OutlineInputBorder(),
+            ),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<String>(
+            value: _selectedProfession,
+            decoration: const InputDecoration(
+              labelText: 'Profession',
+              border: OutlineInputBorder(),
+            ),
+            items: _professions
+                .map(
+                  (profession) => DropdownMenuItem(
+                    value: profession,
+                    child: Text(profession),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) => setState(() => _selectedProfession = value),
+          ),
+          const SizedBox(height: 16),
+          DropdownButtonFormField<String>(
+            value: _selectedSource,
+            decoration: const InputDecoration(
+              labelText: 'How did you hear about us?',
+              border: OutlineInputBorder(),
+            ),
+            items: _sources
+                .map(
+                  (source) => DropdownMenuItem(
+                    value: source,
+                    child: Text(source),
+                  ),
+                )
+                .toList(),
+            onChanged: (value) => setState(() => _selectedSource = value),
+          ),
+        ],
+      ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async => false,
-      child: Scaffold(
-        appBar: AppBar(
-          backgroundColor: Colors.grey[50],
-          elevation: 0,
-          automaticallyImplyLeading: false,
-          title: const Text(
-            'Profile Setup',
-            style: TextStyle(
-              color: Colors.black,
-              fontSize: 32,
-              fontWeight: FontWeight.bold,
-            ),
-          ),
+    final theme = Theme.of(context);
+    return Scaffold(
+      backgroundColor: Colors.white,
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        automaticallyImplyLeading: false,
+        titleSpacing: 16,
+        title: SurveyProgressIndicator(
+          totalSteps: _totalSteps,
+          currentStep: _currentStep,
         ),
-        body: SafeArea(
+        actions: [
+          TextButton(
+            onPressed: _handleExit,
+            child: const Text('Exit'),
+          ),
+        ],
+        leading: _currentStep > 0
+            ? TextButton(
+                onPressed: _handleBack,
+                child: const Text('Back'),
+              )
+            : null,
+      ),
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 16),
           child: Column(
             children: [
-              Padding(
-                padding: const EdgeInsets.all(16.0),
-                child: Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    LinearProgressIndicator(
-                      value: _progressValue,
-                      backgroundColor: Colors.grey[300],
-                      valueColor: const AlwaysStoppedAnimation<Color>(Color(0xFF6D28D9)),
-                      minHeight: 8,
-                    ),
-                    const SizedBox(height: 8),
-                    Text(
-                      '${(_progressValue * 100).toInt()}% Complete',
-                      style: const TextStyle(color: Color(0xFF6D28D9), fontWeight: FontWeight.bold),
-                    ),
-                  ],
-                ),
-              ),
               Expanded(
                 child: SingleChildScrollView(
-                  padding: const EdgeInsets.all(16.0),
-                  child: _controller == null
-                      ? const SizedBox.shrink()
-                      : AnimatedBuilder(
-                          animation: _controller!,
-                          builder: (context, child) {
-                            return Opacity(
-                              opacity: _fadeAnimation?.value ?? 1.0,
-                              child: Transform.translate(
-                                offset: _slideAnimation?.value ?? Offset.zero,
-                                child: child,
-                              ),
-                            );
-                          },
-                          child: Form(
-                            key: _formKey,
-                            child: Column(
-                              crossAxisAlignment: CrossAxisAlignment.start,
-                              children: [
-                                Center(
-                                  child: Stack(
-                                    alignment: Alignment.bottomRight,
-                                    children: [
-                                      CircleAvatar(
-                                        radius: 50,
-                                        backgroundImage: _profileImage != null
-                                            ? FileImage(_profileImage!)
-                                            : (_selectedAvatar != null ? AssetImage(_selectedAvatar!) as ImageProvider : null),
-                                        child: _profileImage == null && _selectedAvatar == null
-                                            ? const Icon(Icons.person, size: 50)
-                                            : null,
-                                      ),
-                                      GestureDetector(
-                                        onTap: _pickImage,
-                                        child: Container(
-                                          padding: const EdgeInsets.all(8),
-                                          decoration: const BoxDecoration(
-                                            shape: BoxShape.circle,
-                                            color: Color(0xFF6D28D9),
-                                          ),
-                                          child: const Icon(Icons.camera_alt, color: Colors.white, size: 20),
-                                        ),
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                                const SizedBox(height: 20),
-                                TextFormField(
-                                  controller: _nameController,
-                                  decoration: _buildInputDecoration('Full Name'),
-                                  validator: (value) => value == null || value.trim().isEmpty ? 'Required' : null,
-                                  onChanged: (_) => _updateProgress(),
-                                ),
-                                const SizedBox(height: 16),
-                                TextFormField(
-                                  controller: _usernameController,
-                                  decoration: _buildInputDecoration('Username'),
-                                  validator: (value) => value == null || value.trim().isEmpty ? 'Required' : null,
-                                  onChanged: (_) => _updateProgress(),
-                                ),
-                                const SizedBox(height: 16),
-                                TextFormField(
-                                  controller: _bioController,
-                                  maxLines: 3,
-                                  decoration: _buildInputDecoration('Bio (optional)'),
-                                  onChanged: (_) => _updateProgress(),
-                                ),
-                                const SizedBox(height: 16),
-                                InkWell(
-                                  onTap: () => _selectDate(context),
-                                  child: InputDecorator(
-                                    decoration: _buildInputDecoration('Date of Birth'),
-                                    child: Text(
-                                      _selectedDate == null
-                                          ? 'Select date'
-                                          : '${_selectedDate!.day}/${_selectedDate!.month}/${_selectedDate!.year}',
-                                    ),
-                                  ),
-                                ),
-                                const SizedBox(height: 16),
-                                DropdownButtonFormField<String>(
-                                  value: _selectedProfession,
-                                  decoration: _buildInputDecoration('Profession'),
-                                  items: _professions
-                                      .map((value) => DropdownMenuItem(value: value, child: Text(value)))
-                                      .toList(),
-                                  onChanged: (newValue) {
-                                    setState(() {
-                                      _selectedProfession = newValue;
-                                      _updateProgress();
-                                    });
-                                  },
-                                ),
-                                const SizedBox(height: 16),
-                                DropdownButtonFormField<String>(
-                                  value: _selectedSource,
-                                  decoration: _buildInputDecoration('How did you hear about us?'),
-                                  items: _sources
-                                      .map((value) => DropdownMenuItem(value: value, child: Text(value)))
-                                      .toList(),
-                                  onChanged: (newValue) {
-                                    setState(() {
-                                      _selectedSource = newValue;
-                                      _updateProgress();
-                                    });
-                                  },
-                                ),
-                                const SizedBox(height: 24),
-                                if (_errorMessage != null)
-                                  Padding(
-                                    padding: const EdgeInsets.only(bottom: 12.0),
-                                    child: Text(
-                                      _errorMessage!,
-                                      style: const TextStyle(color: Colors.redAccent),
-                                    ),
-                                  ),
-                                ElevatedButton(
-                                  onPressed: _isSubmitting ? null : _saveProfileAndComplete,
-                                  style: ElevatedButton.styleFrom(
-                                    backgroundColor: const Color(0xFF6D28D9),
-                                    foregroundColor: Colors.white,
-                                    minimumSize: const Size(double.infinity, 50),
-                                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
-                                  ),
-                                  child: _isSubmitting
-                                      ? const CircularProgressIndicator(color: Colors.white)
-                                      : const Text('Submit'),
-                                ),
-                              ],
-                            ),
-                          ),
-                        ),
+                  child: AnimatedSwitcher(
+                    duration: const Duration(milliseconds: 300),
+                    transitionBuilder: (child, animation) => FadeTransition(
+                      opacity: animation,
+                      child: SlideTransition(
+                        position: Tween<Offset>(
+                          begin: const Offset(0.1, 0.05),
+                          end: Offset.zero,
+                        ).animate(animation),
+                        child: child,
+                      ),
+                    ),
+                    child: Padding(
+                      key: ValueKey(_currentStep),
+                      padding: const EdgeInsets.only(top: 8),
+                      child: _isProfileStep
+                          ? _buildProfileStep(theme)
+                          : _buildQuestionStep(_questions[_currentStep], theme),
+                    ),
+                  ),
+                ),
+              ),
+              if (_errorMessage != null)
+                Padding(
+                  padding: const EdgeInsets.only(bottom: 12),
+                  child: Text(
+                    _errorMessage!,
+                    style: const TextStyle(color: Colors.redAccent),
+                  ),
+                ),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton(
+                  onPressed: _isSubmitting ? null : _handleNext,
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: const Color(0xFF6D28D9),
+                    foregroundColor: Colors.white,
+                    padding: const EdgeInsets.symmetric(vertical: 16),
+                    textStyle: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+                    shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+                  ),
+                  child: _isSubmitting
+                      ? const SizedBox(
+                          height: 22,
+                          width: 22,
+                          child: CircularProgressIndicator(color: Colors.white, strokeWidth: 2),
+                        )
+                      : Text(_isProfileStep ? 'Finish' : 'Next'),
                 ),
               ),
             ],

--- a/lib/services/auth_state.dart
+++ b/lib/services/auth_state.dart
@@ -276,6 +276,7 @@ class AuthStateNotifier extends ChangeNotifier {
     String? profession,
     String? heardFrom,
     String? avatarUrl,
+    Map<String, dynamic>? onboarding,
   }) async {
     _ensureAuthenticated();
     final payload = {
@@ -288,7 +289,19 @@ class AuthStateNotifier extends ChangeNotifier {
       'avatar_url': avatarUrl,
       'survey_completed': true,
       'age': _calculateAge(dateOfBirth),
-    }..removeWhere((key, value) => value == null || (value is String && value.isEmpty));
+      'onboarding': onboarding,
+    }..removeWhere((key, value) {
+        if (value == null) {
+          return true;
+        }
+        if (value is String) {
+          return value.isEmpty;
+        }
+        if (value is Map && value.isEmpty) {
+          return true;
+        }
+        return false;
+      });
 
     final response = await _post(
       '/users/profile/onboarding',

--- a/lib/services/survey_service.dart
+++ b/lib/services/survey_service.dart
@@ -1,0 +1,42 @@
+import 'package:meta/meta.dart';
+
+import 'auth_state.dart';
+
+@immutable
+class SurveyPayload {
+  final String fullName;
+  final String username;
+  final String? bio;
+  final String? profession;
+  final String? heardFrom;
+  final Map<String, dynamic>? onboarding;
+
+  const SurveyPayload({
+    required this.fullName,
+    required this.username,
+    this.bio,
+    this.profession,
+    this.heardFrom,
+    this.onboarding,
+  });
+}
+
+class SurveyService {
+  final AuthState _authState;
+
+  SurveyService(this._authState);
+
+  Future<void> submitSurvey(SurveyPayload payload) async {
+    await _authState.completeProfile(
+      fullName: payload.fullName,
+      username: payload.username,
+      bio: payload.bio,
+      dateOfBirth: null,
+      profession: payload.profession,
+      heardFrom: payload.heardFrom,
+      avatarUrl: null,
+      onboarding: payload.onboarding,
+    );
+    await _authState.refreshProfile();
+  }
+}

--- a/test/survey/survey_model_test.dart
+++ b/test/survey/survey_model_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pocket_llm/models/survey_model.dart';
+
+void main() {
+  group('SurveyResponse', () {
+    test('copyWithAnswer stores responses immutably', () {
+      const original = SurveyResponse(answers: {});
+      final updated = original.copyWithAnswer('age_range', '18_34');
+
+      expect(original.answers.containsKey('age_range'), isFalse);
+      expect(updated.answers['age_range'], equals('18_34'));
+    });
+
+    test('toJson returns a copy of the answers map', () {
+      const response = SurveyResponse(answers: {'gender': 'female'});
+      final json = response.toJson();
+
+      expect(json, equals({'gender': 'female'}));
+      json['gender'] = 'male';
+      expect(response.answers['gender'], equals('female'));
+    });
+  });
+
+  group('SurveyQuestion', () {
+    test('equality compares by value', () {
+      const questionA = SurveyQuestion(
+        id: 'q1',
+        title: 'Title',
+        options: [SurveyOption(id: 'a', label: 'A')],
+      );
+      const questionB = SurveyQuestion(
+        id: 'q1',
+        title: 'Title',
+        options: [SurveyOption(id: 'a', label: 'A')],
+      );
+
+      expect(questionA, equals(questionB));
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- redesign the onboarding survey into a multi-step questionnaire with demographic questions and profile completion
- add reusable survey UI components, models, and service helpers for submitting onboarding data
- store survey answers in the onboarding payload and cover model behavior with unit tests

## Testing
- flutter analyze *(fails: `flutter` not installed in container)*
- flutter test *(fails: `flutter` not installed in container)*
- flutter build apk --debug *(fails: `flutter` not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d4f39a2f68832db47b39970a51f520