### PR TITLE
Add mock database fallback for profile onboarding

### DIFF
--- a/pocketllm-backend/app/core/database.py
+++ b/pocketllm-backend/app/core/database.py
@@ -5,13 +5,179 @@ from __future__ import annotations
 import asyncio
 import logging
 from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import UTC, date, datetime
 from typing import Any, AsyncIterator, Callable, Optional
+from uuid import UUID
 
 import asyncpg
 
 from .config import Settings, get_settings
 
 logger = logging.getLogger(__name__)
+
+
+def _normalise_query(query: str) -> str:
+    """Return a normalised representation of the SQL statement."""
+
+    return " ".join(query.strip().lower().split())
+
+
+@dataclass
+class _ProfileRecord:
+    """In-memory representation of a row in ``public.profiles``."""
+
+    id: UUID
+    email: str
+    full_name: str | None = None
+    username: str | None = None
+    bio: str | None = None
+    date_of_birth: date | None = None
+    age: int | None = None
+    profession: str | None = None
+    heard_from: str | None = None
+    avatar_url: str | None = None
+    survey_completed: bool = False
+    onboarding_responses: dict | None = None
+    deletion_status: str = "active"
+    deletion_requested_at: datetime | None = None
+    deletion_scheduled_for: datetime | None = None
+    created_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+    updated_at: datetime = field(default_factory=lambda: datetime.now(tz=UTC))
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return a mutable dictionary copy of the record."""
+
+        return {
+            "id": self.id,
+            "email": self.email,
+            "full_name": self.full_name,
+            "username": self.username,
+            "bio": self.bio,
+            "date_of_birth": self.date_of_birth,
+            "age": self.age,
+            "profession": self.profession,
+            "heard_from": self.heard_from,
+            "avatar_url": self.avatar_url,
+            "survey_completed": self.survey_completed,
+            "onboarding_responses": self.onboarding_responses,
+            "deletion_status": self.deletion_status,
+            "deletion_requested_at": self.deletion_requested_at,
+            "deletion_scheduled_for": self.deletion_scheduled_for,
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+        }
+
+
+class _MockConnection:
+    """Lightweight stand-in for :class:`asyncpg.Connection`."""
+
+    def __init__(self, store: "_InMemoryStore") -> None:
+        self._store = store
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        return await self._store.fetch(query, *args)
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        return await self._store.fetchrow(query, *args)
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        return await self._store.fetchval(query, *args)
+
+    async def execute(self, query: str, *args: Any) -> str:
+        return await self._store.execute(query, *args)
+
+    @asynccontextmanager
+    async def transaction(self) -> AsyncIterator["_MockConnection"]:
+        yield self
+
+
+class _InMemoryStore:
+    """In-memory fallback implementation when Postgres is unavailable."""
+
+    def __init__(self) -> None:
+        self._profiles: dict[UUID, _ProfileRecord] = {}
+
+    async def fetch(self, query: str, *args: Any) -> list[dict[str, Any]]:
+        row = await self.fetchrow(query, *args)
+        return [row] if row else []
+
+    async def fetchrow(self, query: str, *args: Any) -> dict[str, Any] | None:
+        normalised = _normalise_query(query)
+        if normalised.startswith("select * from public.profiles where id = $1"):
+            profile = self._profiles.get(args[0])
+            return profile.as_dict() if profile else None
+        if normalised.startswith("update public.profiles set"):
+            return await self._handle_profiles_update(query, *args)
+        logger.warning("Mock database received unsupported fetchrow query: %s", query)
+        return None
+
+    async def fetchval(self, query: str, *args: Any) -> Any:
+        rows = await self.fetch(query, *args)
+        if not rows:
+            return None
+        return next(iter(rows[0].values()))
+
+    async def execute(self, query: str, *args: Any) -> str:
+        normalised = _normalise_query(query)
+        if normalised.startswith("insert into public.profiles"):
+            await self._upsert_profile(*args)
+            return "INSERT 0 1"
+        if normalised.startswith("update public.profiles set"):
+            await self._handle_profiles_update(query, *args)
+            return "UPDATE 1"
+        logger.warning("Mock database received unsupported execute query: %s", query)
+        return ""
+
+    async def _upsert_profile(self, user_id: UUID, email: str, full_name: str | None) -> None:
+        now = datetime.now(tz=UTC)
+        record = self._profiles.get(user_id)
+        if record is None:
+            record = _ProfileRecord(id=user_id, email=email, full_name=full_name)
+            self._profiles[user_id] = record
+        else:
+            record.email = email
+            if full_name is not None:
+                record.full_name = full_name
+            record.updated_at = now
+
+    async def _handle_profiles_update(self, query: str, *args: Any) -> dict[str, Any] | None:
+        normalised = _normalise_query(query)
+        user_id: UUID = args[0]
+        record = self._profiles.get(user_id)
+        if record is None:
+            return None
+        now = datetime.now(tz=UTC)
+
+        if "set survey_completed = $2" in normalised:
+            record.survey_completed = bool(args[1])
+            record.onboarding_responses = args[2]
+            record.updated_at = now
+            return record.as_dict()
+
+        if "set deletion_status = 'pending'" in normalised:
+            record.deletion_status = "pending"
+            record.deletion_requested_at = now
+            record.deletion_scheduled_for = args[1]
+            record.updated_at = now
+            return {
+                "deletion_requested_at": record.deletion_requested_at,
+                "deletion_scheduled_for": record.deletion_scheduled_for,
+            }
+
+        if "set deletion_status = 'active'" in normalised and "$2" not in normalised:
+            record.deletion_status = "active"
+            record.deletion_requested_at = None
+            record.deletion_scheduled_for = None
+            record.updated_at = now
+            return record.as_dict()
+
+        set_clause = query.split("SET", 1)[1].split("updated_at", 1)[0]
+        columns = [part.split("=")[0].strip() for part in set_clause.split(",") if "=" in part]
+        for column, value in zip(columns, args[1:]):
+            setattr(record, column, value)
+        record.updated_at = now
+        return record.as_dict()
 
 
 class Database:
@@ -21,6 +187,7 @@ class Database:
         self._settings = settings
         self._pool: Optional[asyncpg.Pool] = None
         self._lock = asyncio.Lock()
+        self._mock_store: _InMemoryStore | None = None
 
     async def connect(self) -> None:
         """Create the connection pool if it has not been initialised."""
@@ -31,6 +198,8 @@ class Database:
         async with self._lock:
             if self._pool is None:
                 if not self._settings.database_url:
+                    if self._mock_store is None:
+                        self._mock_store = _InMemoryStore()
                     logger.warning("Database URL is not configured. Running in mock mode.")
                     return
                 self._pool = await asyncpg.create_pool(
@@ -58,11 +227,12 @@ class Database:
         if self._pool is None:
             await self.connect()
 
-        # If we're in mock mode (no database URL), yield a mock connection
         if self._pool is None:
-            raise RuntimeError("Database is not configured. Cannot establish connection.")
-            
-        assert self._pool is not None, "Database pool is not initialised"
+            if self._mock_store is None:
+                raise RuntimeError("Database is not configured. Cannot establish connection.")
+            yield _MockConnection(self._mock_store)
+            return
+
         connection = await self._pool.acquire()
         try:
             yield connection
@@ -72,6 +242,11 @@ class Database:
     @asynccontextmanager
     async def transaction(self) -> AsyncIterator[asyncpg.Connection]:
         """Acquire a connection and wrap calls in a transaction."""
+
+        if self._pool is None and self._mock_store is not None:
+            async with _MockConnection(self._mock_store).transaction() as connection:
+                yield connection
+            return
 
         async with self.connection() as connection:
             async with connection.transaction():

--- a/pocketllm-backend/app/schemas/auth.py
+++ b/pocketllm-backend/app/schemas/auth.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, EmailStr, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field, model_validator
 
 
 class AuthenticatedUser(BaseModel):
@@ -39,9 +39,19 @@ class AuthTokens(BaseModel):
 class SignUpRequest(BaseModel):
     """Payload used to register a user through Supabase."""
 
+    model_config = ConfigDict(populate_by_name=True)
+
     email: EmailStr
     password: str = Field(min_length=8)
     full_name: Optional[str] = Field(default=None, max_length=120)
+
+    @model_validator(mode="before")
+    @classmethod
+    def _populate_full_name(cls, data: Any) -> Any:
+        if isinstance(data, dict) and "full_name" not in data and "name" in data:
+            data = dict(data)
+            data["full_name"] = data.get("name")
+        return data
 
 
 class AccountStatus(BaseModel):

--- a/pocketllm-backend/tests/test_auth_schema.py
+++ b/pocketllm-backend/tests/test_auth_schema.py
@@ -1,0 +1,13 @@
+"""Unit tests for authentication schemas."""
+
+from __future__ import annotations
+
+from app.schemas.auth import SignUpRequest
+
+
+def test_sign_up_request_accepts_name_alias() -> None:
+    payload = SignUpRequest.model_validate(
+        {"email": "user@example.com", "password": "password123", "name": "Example"}
+    )
+
+    assert payload.full_name == "Example"

--- a/pocketllm-backend/tests/test_database_mock.py
+++ b/pocketllm-backend/tests/test_database_mock.py
@@ -1,0 +1,61 @@
+"""Tests for the in-memory database fallback used in mock mode."""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from app.core.config import Settings
+from app.core.database import Database
+
+
+INSERT_PROFILE_QUERY = """
+INSERT INTO public.profiles (id, email, full_name)
+VALUES ($1, $2, $3)
+ON CONFLICT (id) DO UPDATE SET
+    email = EXCLUDED.email,
+    full_name = COALESCE(EXCLUDED.full_name, public.profiles.full_name),
+    updated_at = NOW()
+"""
+
+SELECT_PROFILE_QUERY = "SELECT * FROM public.profiles WHERE id = $1"
+
+COMPLETE_ONBOARDING_QUERY = """
+UPDATE public.profiles
+SET survey_completed = $2,
+    onboarding_responses = $3,
+    updated_at = NOW()
+WHERE id = $1
+RETURNING *
+"""
+
+
+@pytest.mark.asyncio
+async def test_mock_database_upsert_and_fetch_profile() -> None:
+    settings = Settings(database_url=None)
+    database = Database(settings=settings)
+    user_id = uuid.uuid4()
+
+    await database.execute(INSERT_PROFILE_QUERY, user_id, "user@example.com", "Test User")
+    record = await database.fetchrow(SELECT_PROFILE_QUERY, user_id)
+
+    assert record is not None
+    assert record["email"] == "user@example.com"
+    assert record["full_name"] == "Test User"
+    assert record["survey_completed"] is False
+
+
+@pytest.mark.asyncio
+async def test_mock_database_updates_onboarding_fields() -> None:
+    settings = Settings(database_url=None)
+    database = Database(settings=settings)
+    user_id = uuid.uuid4()
+
+    await database.execute(INSERT_PROFILE_QUERY, user_id, "user@example.com", "Test User")
+    await database.fetchrow(COMPLETE_ONBOARDING_QUERY, user_id, True, {"step": "done"})
+
+    record = await database.fetchrow(SELECT_PROFILE_QUERY, user_id)
+    assert record is not None
+    assert record["survey_completed"] is True
+    assert record["onboarding_responses"] == {"step": "done"}


### PR DESCRIPTION
## Summary
- add an in-memory profile store so signup/onboarding flows work without a configured database URL
- allow the signup schema to accept a `name` field as an alias for `full_name`
- cover the fallback behaviour and schema alias with new unit tests

## Testing
- pytest *(fails: missing Python dependencies in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d63ab01e84832dbe37a96158e00500