### PR TITLE
Update PocketLLM to new API base

### DIFF
--- a/docs/api-documentation.md
+++ b/docs/api-documentation.md
@@ -23,11 +23,11 @@ For production deployments, replace `localhost:8000` with your server address.
 Production demo:
 
 ```
-https://pocket-llm-lemon.vercel.app/v1
+https://pocket-llm-api.vercel.app/v1
 ```
 
 Swagger UI is available locally at `http://localhost:8000/api/docs` (also aliased at `http://localhost:8000/docs`) and in the hosted demo at
-`https://pocket-llm-lemon.vercel.app/docs` (legacy path `https://pocket-llm-lemon.vercel.app/api/docs`) unless disabled via `ENABLE_SWAGGER_DOCS`. The root endpoint (`GET /`) echoes
+`https://pocket-llm-api.vercel.app/docs` (legacy path `https://pocket-llm-api.vercel.app/api/docs`) unless disabled via `ENABLE_SWAGGER_DOCS`. The root endpoint (`GET /`) echoes
 the active docs path for quick verification.
 
 ## 🔐 Authentication

--- a/docs/api-maintenance.md
+++ b/docs/api-maintenance.md
@@ -96,7 +96,7 @@ http://localhost:8000/api/docs (or http://localhost:8000/docs)
 
 Production demo:
 ```
-https://pocket-llm-lemon.vercel.app/docs (legacy path https://pocket-llm-lemon.vercel.app/api/docs)
+https://pocket-llm-api.vercel.app/docs (legacy path https://pocket-llm-api.vercel.app/api/docs)
 ```
 
 To view the latest documentation:

--- a/lib/component/chat_interface.dart
+++ b/lib/component/chat_interface.dart
@@ -23,6 +23,7 @@ import '../services/chat_history_service.dart';
 import 'appbar/chat_history.dart';
 import '../services/error_service.dart';
 import '../services/search_service.dart';
+import '../services/pocket_llm_service.dart';
 import '../pages/search_settings_page.dart';
 
 class ChatInterface extends StatefulWidget {
@@ -58,7 +59,7 @@ class ChatInterfaceState extends State<ChatInterface> {
   
   // Restore missing variables
   final String apiKey = 'ddc-m4qlvrgpt1W1E4ZXc4bvm5T5Z6CRFLeXRCx9AbRuQOcGpFFrX2';
-  final String apiUrl = 'https://api.sree.shop/v1/chat/completions';
+  final String apiUrl = '${PocketLLMService.baseUrl}/chat/completions';
   final TavilyService _tavilyService = TavilyService();
   bool _isOnline = false;
 

--- a/lib/pages/auth/auth_page.dart
+++ b/lib/pages/auth/auth_page.dart
@@ -9,6 +9,28 @@ import 'user_survey_page.dart';
 
 enum _AuthMode { signIn, signUp }
 
+class _StaggeredCurve extends Curve {
+  const _StaggeredCurve({
+    required this.delayFraction,
+    this.curve = Curves.easeOutCubic,
+  });
+
+  final double delayFraction;
+  final Curve curve;
+
+  @override
+  double transform(double t) {
+    if (delayFraction >= 1) {
+      return curve.transform(1);
+    }
+    if (t <= delayFraction) {
+      return 0;
+    }
+    final normalized = ((t - delayFraction) / (1 - delayFraction)).clamp(0.0, 1.0);
+    return curve.transform(normalized);
+  }
+}
+
 class AuthPage extends StatefulWidget {
   final ValueChanged<String>? onLoginSuccess;
   final bool showAppBar;
@@ -695,9 +717,10 @@ class _AuthPageState extends State<AuthPage> {
             padding: EdgeInsets.only(top: index == 0 ? 0 : 12),
             child: TweenAnimationBuilder<double>(
               tween: Tween(begin: 0, end: 1),
-              duration: const Duration(milliseconds: 320),
-              curve: Curves.easeOutCubic,
-              delay: Duration(milliseconds: index * 70),
+              duration: const Duration(milliseconds: 420),
+              curve: _StaggeredCurve(
+                delayFraction: (index * 0.08).clamp(0.0, 0.7),
+              ),
               builder: (context, value, child) => Opacity(
                 opacity: value,
                 child: Transform.translate(

--- a/lib/services/api_config.dart
+++ b/lib/services/api_config.dart
@@ -1,4 +1,6 @@
-const String apiBaseUrl = String.fromEnvironment(
-  'POCKETLLM_API_BASE_URL',
-  defaultValue: 'https://api.sree.shop/v1',
-);
+import 'api_endpoints.dart';
+
+final String apiBaseUrl = ApiEndpoints.buildUri(
+  '',
+  includeApiSuffix: true,
+).toString();

--- a/lib/services/api_endpoints.dart
+++ b/lib/services/api_endpoints.dart
@@ -1,0 +1,143 @@
+import 'package:flutter/foundation.dart';
+
+class ApiEndpoints {
+  ApiEndpoints._();
+
+  static const String defaultBackendBaseUrl = String.fromEnvironment(
+    'POCKETLLM_BACKEND_URL',
+    defaultValue: 'https://pocket-llm-api.vercel.app',
+  );
+
+  static const String defaultDocsUrl = String.fromEnvironment(
+    'POCKETLLM_BACKEND_DOCS_URL',
+    defaultValue: 'https://pocket-llm-api.vercel.app/docs',
+  );
+
+  static const String defaultHealthUrl = String.fromEnvironment(
+    'POCKETLLM_BACKEND_HEALTH_URL',
+    defaultValue: 'https://pocket-llm-api.vercel.app/health',
+  );
+
+  static const String defaultApiSuffix = String.fromEnvironment(
+    'POCKETLLM_BACKEND_SUFFIX',
+    defaultValue: 'v1',
+  );
+
+  static const List<String> defaultBaseUrls = <String>[
+    defaultBackendBaseUrl,
+    'https://pocket-llm-api.vercel.app',
+  ];
+
+  static String resolveBaseUrl([String? override]) {
+    final value = (override ?? defaultBackendBaseUrl).trim();
+    if (value.isEmpty) {
+      return defaultBackendBaseUrl;
+    }
+
+    var normalized = value;
+    while (normalized.endsWith('/')) {
+      normalized = normalized.substring(0, normalized.length - 1);
+    }
+    return normalized;
+  }
+
+  static String resolveDocsUrl([String? override]) => _normalizeUrl(override ?? defaultDocsUrl);
+
+  static String resolveHealthUrl([String? override]) => _normalizeUrl(override ?? defaultHealthUrl);
+
+  static Uri buildUri(
+    String path, {
+    Map<String, String>? queryParameters,
+    bool includeApiSuffix = true,
+    String? overrideBaseUrl,
+  }) {
+    final base = resolveBaseUrl(overrideBaseUrl);
+    final buffer = StringBuffer(base);
+
+    final suffix = includeApiSuffix ? defaultApiSuffix.trim() : '';
+    if (suffix.isNotEmpty) {
+      final sanitizedSuffix = _trimSlashes(suffix);
+      final lowerSuffix = '/${sanitizedSuffix.toLowerCase()}';
+      if (!base.toLowerCase().endsWith(lowerSuffix)) {
+        buffer.write('/$sanitizedSuffix');
+      }
+    }
+
+    final normalizedPath = _trimLeadingSlash(path);
+    if (normalizedPath.isNotEmpty) {
+      buffer.write('/$normalizedPath');
+    }
+
+    final uri = Uri.parse(buffer.toString());
+    return uri.replace(queryParameters: queryParameters);
+  }
+
+  static List<String> mergeBaseUrls(Iterable<String> additional) {
+    final seen = <String>{};
+    final resolved = <String>[];
+
+    void add(String value) {
+      final normalized = resolveBaseUrl(value);
+      if (seen.add(normalized)) {
+        resolved.add(normalized);
+      }
+    }
+
+    for (final candidate in defaultBaseUrls) {
+      if (candidate.trim().isEmpty) continue;
+      add(candidate);
+    }
+
+    for (final candidate in additional) {
+      if (candidate.trim().isEmpty) continue;
+      add(candidate);
+    }
+
+    if (resolved.isEmpty) {
+      resolved.add(resolveBaseUrl(defaultBackendBaseUrl));
+    }
+
+    debugPrint('ApiEndpoints.mergeBaseUrls resolved: $resolved');
+    return List.unmodifiable(resolved);
+  }
+
+  static String get docsUrl => resolveDocsUrl();
+
+  static String get healthUrl => resolveHealthUrl();
+
+  static Uri authSignIn({String? baseUrl}) =>
+      buildUri('/auth/signin', overrideBaseUrl: baseUrl);
+
+  static Uri authSignUp({String? baseUrl}) =>
+      buildUri('/auth/signup', overrideBaseUrl: baseUrl);
+
+  static Uri userProfile({String? baseUrl}) =>
+      buildUri('/users/profile', overrideBaseUrl: baseUrl);
+
+  static String _trimLeadingSlash(String value) {
+    var result = value.trim();
+    while (result.startsWith('/')) {
+      result = result.substring(1);
+    }
+    return result;
+  }
+
+  static String _trimSlashes(String value) {
+    var result = value.trim();
+    while (result.startsWith('/')) {
+      result = result.substring(1);
+    }
+    while (result.endsWith('/')) {
+      result = result.substring(0, result.length - 1);
+    }
+    return result;
+  }
+
+  static String _normalizeUrl(String value) {
+    final trimmed = value.trim();
+    if (trimmed.isEmpty) {
+      return trimmed;
+    }
+    return trimmed.endsWith('/') ? trimmed.substring(0, trimmed.length - 1) : trimmed;
+  }
+}

--- a/lib/services/pocket_llm_service.dart
+++ b/lib/services/pocket_llm_service.dart
@@ -6,9 +6,10 @@ import 'package:http/http.dart' as http;
 
 import '../component/models.dart';
 import 'api_config.dart';
+import 'api_endpoints.dart';
 
 class PocketLLMService {
-  static const String baseUrl = apiBaseUrl;
+  static final String baseUrl = ApiEndpoints.resolveBaseUrl(apiBaseUrl);
   static const _secureStorage = FlutterSecureStorage();
   static const String _apiKeyKey = 'pocketllm_api_key';
 
@@ -59,7 +60,11 @@ class PocketLLMService {
       }
 
       final response = await http.get(
-        Uri.parse('$baseUrl/models'),
+        ApiEndpoints.buildUri(
+          '/models',
+          includeApiSuffix: false,
+          overrideBaseUrl: baseUrl,
+        ),
         headers: {
           'Authorization': 'Bearer $apiKey',
           'Content-Type': 'application/json',
@@ -120,7 +125,11 @@ class PocketLLMService {
       messages.add({'role': 'user', 'content': userMessage});
 
       // Ensure the full URL is constructed correctly
-      final uri = Uri.parse('$baseUrl/chat/completions');
+      final uri = ApiEndpoints.buildUri(
+        '/chat/completions',
+        includeApiSuffix: false,
+        overrideBaseUrl: baseUrl,
+      );
       debugPrint('Making request to: $uri');
 
       final response = await http.post(
@@ -175,7 +184,11 @@ class PocketLLMService {
       }
 
       final response = await http.get(
-        Uri.parse('${config.baseUrl}/models'),
+        ApiEndpoints.buildUri(
+          '/models',
+          includeApiSuffix: false,
+          overrideBaseUrl: config.baseUrl,
+        ),
         headers: {
           'Authorization': 'Bearer $apiKey',
           'Content-Type': 'application/json',

--- a/pocketllm-backend/POSTMAN_API_GUIDE.md
+++ b/pocketllm-backend/POSTMAN_API_GUIDE.md
@@ -8,7 +8,7 @@ http://localhost:8000/v1
 For the hosted demo deployment you can target:
 
 ```
-https://pocket-llm-lemon.vercel.app/v1
+https://pocket-llm-api.vercel.app/v1
 ```
 
 ## 🚀 Getting Started
@@ -30,7 +30,7 @@ Follow these steps to prepare the NestJS backend before exercising the API colle
    npm run start:dev
    ```
    The REST API will be available at `http://localhost:8000/v1` and Swagger documentation at `http://localhost:8000/api/docs` (aliased at `http://localhost:8000/docs`).
-   In production (Vercel demo) the docs are published at `https://pocket-llm-lemon.vercel.app/docs` (legacy path `https://pocket-llm-lemon.vercel.app/api/docs`).
+   In production (Vercel demo) the docs are published at `https://pocket-llm-api.vercel.app/docs` (legacy path `https://pocket-llm-api.vercel.app/api/docs`).
 4. **Authenticate requests**
    Use `POST /v1/auth/signin` to obtain an access token and send it in the `Authorization: Bearer <token>` header when calling protected routes. The Users, Chats, and Jobs controllers are guarded by the Supabase JWT so every request must include a valid token. You can always call `GET /v1` to verify routing and to see the currently active documentation links exposed by the server.
 

--- a/pocketllm-backend/app/core/config.py
+++ b/pocketllm-backend/app/core/config.py
@@ -35,7 +35,7 @@ class Settings(BaseSettings):
     cors_origin: str = "*"
 
     # URLs
-    backend_base_url: str = "https://pocket-llm-lemon.vercel.app/"
+    backend_base_url: str = "https://pocket-llm-api.vercel.app/"
     fallback_backend_url: str = "https://pocketllm.onrender.com"
 
     # Supabase configuration


### PR DESCRIPTION
## Summary
- centralize backend URL management with a new `ApiEndpoints` helper and update API services to the `https://pocket-llm-api.vercel.app` deployment
- refresh authentication UI animation and chat interface wiring to use the shared backend configuration
- update documentation and backend defaults to reference the new production base URL and docs endpoints

## Testing
- Unable to run `flutter analyze` *(Flutter SDK download blocked by proxy 403)*


------
https://chatgpt.com/codex/tasks/task_e_68d652d0e704832d9312aed6ba9f2df3