### PR TITLE
Add static waitlist landing page for PocketLLM

### DIFF
--- a/web/waitlist.html
+++ b/web/waitlist.html
@@ -1,0 +1,453 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>PocketLLM Waitlist</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light dark;
+      --bg: #0f172a;
+      --fg: #f8fafc;
+      --primary: #6366f1;
+      --primary-accent: rgba(99, 102, 241, 0.18);
+      --card-bg: rgba(15, 23, 42, 0.65);
+      --border: rgba(148, 163, 184, 0.4);
+      --muted: #cbd5f5;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+      background: radial-gradient(circle at top, rgba(99, 102, 241, 0.25), transparent 60%),
+        radial-gradient(circle at bottom, rgba(14, 165, 233, 0.2), transparent 55%),
+        var(--bg);
+      color: var(--fg);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 3rem 1.5rem 6rem;
+    }
+
+    .page {
+      width: min(1100px, 100%);
+    }
+
+    header {
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      margin-bottom: 5rem;
+    }
+
+    header .logo {
+      font-size: 1.25rem;
+      font-weight: 700;
+      letter-spacing: -0.02em;
+    }
+
+    header nav {
+      display: flex;
+      gap: 1.75rem;
+      font-size: 0.95rem;
+      color: rgba(248, 250, 252, 0.75);
+    }
+
+    header a {
+      color: inherit;
+      text-decoration: none;
+      position: relative;
+    }
+
+    header a::after {
+      content: "";
+      position: absolute;
+      left: 0;
+      bottom: -0.35rem;
+      width: 100%;
+      height: 2px;
+      background: var(--primary);
+      transform: scaleX(0);
+      transform-origin: left;
+      transition: transform 0.2s ease;
+    }
+
+    header a:hover::after {
+      transform: scaleX(1);
+    }
+
+    .hero {
+      display: grid;
+      gap: 2.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+      align-items: center;
+    }
+
+    .hero-text h1 {
+      font-size: clamp(2.5rem, 6vw, 3.75rem);
+      line-height: 1.05;
+      margin-bottom: 1.5rem;
+      letter-spacing: -0.04em;
+    }
+
+    .hero-text p {
+      font-size: 1.1rem;
+      color: rgba(248, 250, 252, 0.7);
+      line-height: 1.6;
+      margin-bottom: 2.5rem;
+    }
+
+    .hero-highlight {
+      display: inline-flex;
+      align-items: center;
+      padding: 0.4rem 1rem;
+      background: rgba(99, 102, 241, 0.15);
+      border: 1px solid rgba(99, 102, 241, 0.3);
+      border-radius: 999px;
+      margin-bottom: 1.5rem;
+      font-size: 0.9rem;
+      color: #c7d2fe;
+      gap: 0.5rem;
+    }
+
+    .waitlist-card {
+      background: linear-gradient(160deg, rgba(15, 23, 42, 0.85), rgba(30, 41, 59, 0.65));
+      border: 1px solid var(--border);
+      border-radius: 24px;
+      padding: 2.5rem;
+      box-shadow: 0 32px 80px rgba(15, 23, 42, 0.45);
+      backdrop-filter: blur(18px);
+    }
+
+    .waitlist-card h2 {
+      font-size: 1.75rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .waitlist-card p {
+      font-size: 0.95rem;
+      color: rgba(248, 250, 252, 0.65);
+      line-height: 1.6;
+      margin-bottom: 1.75rem;
+    }
+
+    form {
+      display: grid;
+      gap: 1rem;
+    }
+
+    label {
+      font-size: 0.95rem;
+      color: var(--muted);
+    }
+
+    input[type="text"],
+    input[type="email"] {
+      width: 100%;
+      padding: 0.9rem 1rem;
+      border-radius: 14px;
+      border: 1px solid rgba(148, 163, 184, 0.35);
+      background: rgba(15, 23, 42, 0.45);
+      color: var(--fg);
+      font-size: 1rem;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    input:focus {
+      outline: none;
+      border-color: var(--primary);
+      box-shadow: 0 0 0 4px rgba(99, 102, 241, 0.25);
+    }
+
+    button {
+      padding: 1rem 1.2rem;
+      border-radius: 14px;
+      border: none;
+      font-weight: 600;
+      font-size: 1rem;
+      background: linear-gradient(135deg, #6366f1, #8b5cf6);
+      color: white;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    button:hover {
+      transform: translateY(-1px);
+      box-shadow: 0 20px 40px rgba(99, 102, 241, 0.35);
+    }
+
+    .helper-text {
+      font-size: 0.85rem;
+      color: rgba(148, 163, 184, 0.7);
+      margin-top: -0.5rem;
+    }
+
+    .success-message {
+      display: none;
+      margin-top: 1rem;
+      padding: 0.85rem 1rem;
+      border-radius: 12px;
+      background: rgba(34, 197, 94, 0.15);
+      border: 1px solid rgba(34, 197, 94, 0.35);
+      color: #bbf7d0;
+      font-size: 0.95rem;
+    }
+
+    .features {
+      margin-top: 5rem;
+      display: grid;
+      gap: 1.5rem;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    }
+
+    .feature-card {
+      background: rgba(15, 23, 42, 0.4);
+      border-radius: 20px;
+      padding: 1.75rem;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      backdrop-filter: blur(12px);
+    }
+
+    .feature-card h3 {
+      font-size: 1.2rem;
+      margin-bottom: 0.75rem;
+    }
+
+    .feature-card p {
+      color: rgba(248, 250, 252, 0.65);
+      font-size: 0.95rem;
+      line-height: 1.6;
+    }
+
+    .waitlist-table {
+      margin-top: 3.5rem;
+      background: rgba(15, 23, 42, 0.45);
+      border-radius: 18px;
+      border: 1px solid rgba(148, 163, 184, 0.25);
+      overflow: hidden;
+    }
+
+    .waitlist-table h3 {
+      margin: 0;
+      padding: 1.5rem;
+      border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+      font-size: 1.1rem;
+    }
+
+    table {
+      width: 100%;
+      border-collapse: collapse;
+      color: rgba(248, 250, 252, 0.75);
+    }
+
+    th, td {
+      padding: 1rem 1.5rem;
+      text-align: left;
+      font-size: 0.95rem;
+    }
+
+    tr + tr {
+      border-top: 1px solid rgba(148, 163, 184, 0.1);
+    }
+
+    .empty-state {
+      padding: 1.75rem;
+      text-align: center;
+      color: rgba(148, 163, 184, 0.7);
+    }
+
+    footer {
+      margin-top: 4rem;
+      text-align: center;
+      color: rgba(148, 163, 184, 0.6);
+      font-size: 0.85rem;
+    }
+
+    @media (max-width: 768px) {
+      header {
+        flex-direction: column;
+        gap: 1rem;
+        align-items: flex-start;
+      }
+
+      header nav {
+        gap: 1.1rem;
+      }
+
+      .waitlist-card {
+        padding: 2rem;
+      }
+
+      .waitlist-table h3,
+      th,
+      td {
+        padding-left: 1.25rem;
+        padding-right: 1.25rem;
+      }
+    }
+  </style>
+</head>
+<body>
+  <main class="page">
+    <header>
+      <div class="logo">PocketLLM</div>
+      <nav>
+        <a href="#">Product</a>
+        <a href="#">Pricing</a>
+        <a href="#">Docs</a>
+        <a href="#">Community</a>
+      </nav>
+    </header>
+
+    <section class="hero">
+      <div class="hero-text">
+        <div class="hero-highlight">🚀 Beta waitlist now open</div>
+        <h1>Personal AI that fits in your pocket.</h1>
+        <p>
+          PocketLLM delivers private, on-device intelligence with seamless desktop integrations. Join the early access waitlist
+          to be first in line for a new era of personal AI assistants.
+        </p>
+        <div class="features">
+          <div class="feature-card">
+            <h3>Private by design</h3>
+            <p>Run quantized models locally on your phone or securely connect to your desktop host with zero data sharing.</p>
+          </div>
+          <div class="feature-card">
+            <h3>Fluid experiences</h3>
+            <p>Fast chat interface with markdown, memory, and cost tracking—optimized for mobile, desktop, and web.</p>
+          </div>
+          <div class="feature-card">
+            <h3>Seamless handoff</h3>
+            <p>Switch between devices instantly, keep your conversations synced, and bring your favorite models anywhere.</p>
+          </div>
+        </div>
+      </div>
+
+      <div class="waitlist-card">
+        <h2>Save your spot</h2>
+        <p>We will notify you as soon as PocketLLM beta invites roll out. Add teammates or friends to the list anytime.</p>
+        <form id="waitlist-form" novalidate>
+          <div>
+            <label for="name">Full name</label>
+            <input type="text" id="name" name="name" placeholder="Jordan Rivera" required />
+          </div>
+          <div>
+            <label for="email">Work email</label>
+            <input type="email" id="email" name="email" placeholder="jordan@company.com" required />
+            <p class="helper-text">We'll only use this email to send your invite.</p>
+          </div>
+          <button type="submit">Join the waitlist</button>
+          <div class="success-message" role="status" aria-live="polite">
+            You're on the list! We'll be in touch soon.
+          </div>
+        </form>
+      </div>
+    </section>
+
+    <section class="waitlist-table" aria-live="polite">
+      <h3>People in line</h3>
+      <div class="empty-state" id="empty-state">No one has joined yet. Be the first!</div>
+      <table id="waitlist-table" hidden>
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th>Joined</th>
+          </tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
+    <footer>
+      Built with ❤️ by the PocketLLM team • Launching soon on iOS, Android, and Desktop
+    </footer>
+  </main>
+
+  <script>
+    const form = document.getElementById('waitlist-form');
+    const table = document.getElementById('waitlist-table');
+    const tbody = table.querySelector('tbody');
+    const emptyState = document.getElementById('empty-state');
+    const successMessage = document.querySelector('.success-message');
+    const STORAGE_KEY = 'pocketllm-waitlist';
+
+    function loadWaitlist() {
+      try {
+        const entries = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+        entries.forEach(addRow);
+        toggleTable(entries.length > 0);
+      } catch (error) {
+        console.error('Failed to load waitlist from storage.', error);
+        localStorage.removeItem(STORAGE_KEY);
+        toggleTable(false);
+      }
+    }
+
+    function addRow(entry) {
+      const row = document.createElement('tr');
+      row.innerHTML = `
+        <td>${entry.name}</td>
+        <td>${entry.email}</td>
+        <td>${new Date(entry.timestamp).toLocaleString()}</td>
+      `;
+      tbody.appendChild(row);
+    }
+
+    function toggleTable(hasEntries) {
+      table.hidden = !hasEntries;
+      emptyState.style.display = hasEntries ? 'none' : 'block';
+    }
+
+    form.addEventListener('submit', (event) => {
+      event.preventDefault();
+      const formData = new FormData(form);
+      const name = formData.get('name').trim();
+      const email = formData.get('email').trim().toLowerCase();
+
+      if (!name || !email) {
+        alert('Please provide both your name and email.');
+        return;
+      }
+
+      if (!/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
+        alert('Please enter a valid email address.');
+        return;
+      }
+
+      const entry = {
+        name,
+        email,
+        timestamp: Date.now()
+      };
+
+      addRow(entry);
+      toggleTable(true);
+      form.reset();
+      successMessage.style.display = 'block';
+
+      setTimeout(() => {
+        successMessage.style.display = 'none';
+      }, 3200);
+
+      try {
+        const existing = JSON.parse(localStorage.getItem(STORAGE_KEY)) || [];
+        existing.unshift(entry);
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(existing));
+      } catch (error) {
+        console.error('Unable to persist waitlist entry.', error);
+      }
+    });
+
+    loadWaitlist();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a dedicated HTML landing page that markets PocketLLM with a modern SaaS-style hero layout
- include an interactive waitlist form with local storage persistence and real-time queue preview

## Testing
- flutter test *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d662c784b0832daca75f752e3e6866