### PR TITLE
Refactor model catalogue and provider integrations

### DIFF
--- a/pocketllm-backend/API_DOCUMENTATION.md
+++ b/pocketllm-backend/API_DOCUMENTATION.md
@@ -154,13 +154,12 @@ Fetch provider specific model catalogue.
 ## Models
 
 ### `GET /v1/models`
-List stored model configurations.
-- **Response:** `ModelConfiguration[]`
+Aggregate model catalogues from every configured provider.
+- **Response:** `ProviderModel[]`
 
-### `POST /v1/models`
-Create a new model configuration.
-- **Body:** `ModelCreateRequest`
-- **Response:** `ModelConfiguration`
+### `GET /v1/models/saved`
+List stored model configurations for the authenticated user.
+- **Response:** `ModelConfiguration[]`
 
 ### `POST /v1/models/import`
 Bulk import provider models.
@@ -169,11 +168,6 @@ Bulk import provider models.
 
 ### `GET /v1/models/{modelId}`
 Retrieve model details.
-- **Response:** `ModelConfiguration`
-
-### `PUT /v1/models/{modelId}`
-Update configuration details.
-- **Body:** `ModelUpdateRequest`
 - **Response:** `ModelConfiguration`
 
 ### `DELETE /v1/models/{modelId}`

--- a/pocketllm-backend/api_structure.json
+++ b/pocketllm-backend/api_structure.json
@@ -1367,8 +1367,8 @@
         "tags": [
           "models"
         ],
-        "summary": "List saved models",
-        "operationId": "list_models_v1_models_get",
+        "summary": "List provider models",
+        "operationId": "list_provider_models_v1_models_get",
         "responses": {
           "200": {
             "description": "Successful Response",
@@ -1376,10 +1376,10 @@
               "application/json": {
                 "schema": {
                   "items": {
-                    "$ref": "#/components/schemas/ModelConfiguration"
+                    "$ref": "#/components/schemas/ProviderModel"
                   },
                   "type": "array",
-                  "title": "Response List Models V1 Models Get"
+                  "title": "Response List Provider Models V1 Models Get"
                 }
               }
             }
@@ -1390,40 +1390,26 @@
             "HTTPBearer": []
           }
         ]
-      },
-      "post": {
+      }
+    },
+    "/v1/models/saved": {
+      "get": {
         "tags": [
           "models"
         ],
-        "summary": "Create model configuration",
-        "operationId": "create_model_v1_models_post",
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ModelCreateRequest"
-              }
-            }
-          },
-          "required": true
-        },
+        "summary": "List saved models",
+        "operationId": "list_saved_models_v1_models_saved_get",
         "responses": {
           "200": {
             "description": "Successful Response",
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ModelConfiguration"
-                }
-              }
-            }
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/ModelConfiguration"
+                  },
+                  "title": "Response List Saved Models V1 Models Saved Get"
                 }
               }
             }
@@ -1559,62 +1545,6 @@
         "responses": {
           "204": {
             "description": "Successful Response"
-          },
-          "422": {
-            "description": "Validation Error",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/HTTPValidationError"
-                }
-              }
-            }
-          }
-        }
-      },
-      "put": {
-        "tags": [
-          "models"
-        ],
-        "summary": "Update model",
-        "operationId": "update_model_v1_models__model_id__put",
-        "security": [
-          {
-            "HTTPBearer": []
-          }
-        ],
-        "parameters": [
-          {
-            "name": "model_id",
-            "in": "path",
-            "required": true,
-            "schema": {
-              "type": "string",
-              "format": "uuid",
-              "title": "Model Id"
-            }
-          }
-        ],
-        "requestBody": {
-          "required": true,
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/ModelUpdateRequest"
-              }
-            }
-          }
-        },
-        "responses": {
-          "200": {
-            "description": "Successful Response",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ModelConfiguration"
-                }
-              }
-            }
           },
           "422": {
             "description": "Validation Error",
@@ -2571,55 +2501,6 @@
         "title": "ModelConfiguration",
         "description": "User specific model configuration."
       },
-      "ModelCreateRequest": {
-        "properties": {
-          "provider": {
-            "type": "string",
-            "title": "Provider"
-          },
-          "model": {
-            "type": "string",
-            "title": "Model"
-          },
-          "name": {
-            "type": "string",
-            "title": "Name"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "settings": {
-            "$ref": "#/components/schemas/ModelSettings"
-          }
-        },
-        "type": "object",
-        "required": [
-          "provider",
-          "model",
-          "name"
-        ],
-        "title": "ModelCreateRequest",
-        "description": "Create a custom model configuration."
-      },
       "ModelDefaultRequest": {
         "properties": {
           "is_default": {
@@ -2756,67 +2637,6 @@
         "type": "object",
         "title": "ModelSettings",
         "description": "Additional provider specific configuration."
-      },
-      "ModelUpdateRequest": {
-        "properties": {
-          "name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Name"
-          },
-          "display_name": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Display Name"
-          },
-          "description": {
-            "anyOf": [
-              {
-                "type": "string"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Description"
-          },
-          "settings": {
-            "anyOf": [
-              {
-                "$ref": "#/components/schemas/ModelSettings"
-              },
-              {
-                "type": "null"
-              }
-            ]
-          },
-          "is_active": {
-            "anyOf": [
-              {
-                "type": "boolean"
-              },
-              {
-                "type": "null"
-              }
-            ],
-            "title": "Is Active"
-          }
-        },
-        "type": "object",
-        "title": "ModelUpdateRequest",
-        "description": "Update an existing model configuration."
       },
       "OAuthProviderRequest": {
         "properties": {
@@ -3047,7 +2867,6 @@
           "pricing": {
             "anyOf": [
               {
-                "additionalProperties": true,
                 "type": "object"
               },
               {
@@ -3055,10 +2874,48 @@
               }
             ],
             "title": "Pricing"
+          },
+          "provider": {
+            "type": "string",
+            "title": "Provider"
+          },
+          "description": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Description"
+          },
+          "is_active": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Active"
+          },
+          "metadata": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Metadata"
           }
         },
         "type": "object",
         "required": [
+          "provider",
           "id",
           "name"
         ],

--- a/pocketllm-backend/app/api/v1/endpoints/models.py
+++ b/pocketllm-backend/app/api/v1/endpoints/models.py
@@ -6,37 +6,41 @@ from uuid import UUID
 
 from fastapi import APIRouter, Depends
 
-from app.api.deps import get_current_request_user, get_database_dependency
+from app.api.deps import (
+    get_current_request_user,
+    get_database_dependency,
+    get_settings_dependency,
+)
 from app.schemas.auth import TokenPayload
 from app.schemas.models import (
     ModelConfiguration,
-    ModelCreateRequest,
     ModelDefaultRequest,
     ModelImportRequest,
-    ModelUpdateRequest,
 )
+from app.schemas.providers import ProviderModel
 from app.services.models import ModelsService
+from app.services.providers import ProviderModelCatalogue
 
 router = APIRouter(prefix="/models", tags=["models"])
 
 
-@router.get("", response_model=list[ModelConfiguration], summary="List saved models")
+@router.get("", response_model=list[ProviderModel], summary="List provider models")
 async def list_models(
+    user: TokenPayload = Depends(get_current_request_user),
+    settings=Depends(get_settings_dependency),
+) -> list[ProviderModel]:
+    _ = user  # ensure dependency is enforced even if unused
+    catalogue = ProviderModelCatalogue(settings)
+    return await catalogue.list_all_models()
+
+
+@router.get("/saved", response_model=list[ModelConfiguration], summary="List saved models")
+async def list_saved_models(
     user: TokenPayload = Depends(get_current_request_user),
     database=Depends(get_database_dependency),
 ) -> list[ModelConfiguration]:
     service = ModelsService(database=database)
     return await service.list_models(user.sub)
-
-
-@router.post("", response_model=ModelConfiguration, summary="Create model configuration")
-async def create_model(
-    payload: ModelCreateRequest,
-    user: TokenPayload = Depends(get_current_request_user),
-    database=Depends(get_database_dependency),
-) -> ModelConfiguration:
-    service = ModelsService(database=database)
-    return await service.create_model(user.sub, payload)
 
 
 @router.post("/import", response_model=list[ModelConfiguration], summary="Import models from provider")
@@ -78,14 +82,3 @@ async def set_default_model(
 ) -> ModelConfiguration:
     service = ModelsService(database=database)
     return await service.set_default_model(user.sub, model_id, payload)
-
-
-@router.put("/{model_id}", response_model=ModelConfiguration, summary="Update model")
-async def update_model(
-    model_id: UUID,
-    payload: ModelUpdateRequest,
-    user: TokenPayload = Depends(get_current_request_user),
-    database=Depends(get_database_dependency),
-) -> ModelConfiguration:
-    service = ModelsService(database=database)
-    return await service.update_model(user.sub, model_id, payload)

--- a/pocketllm-backend/app/api/v1/endpoints/providers.py
+++ b/pocketllm-backend/app/api/v1/endpoints/providers.py
@@ -13,7 +13,8 @@ from app.schemas.providers import (
     ProviderModel,
     ProviderUpdateRequest,
 )
-from app.services.providers import ProvidersService
+from app.services.provider_configs import ProvidersService
+from app.services.providers import ProviderModelCatalogue
 
 router = APIRouter(prefix="/providers", tags=["providers"])
 
@@ -68,5 +69,5 @@ async def list_provider_models(
     settings=Depends(get_settings_dependency),
     database=Depends(get_database_dependency),
 ) -> list[ProviderModel]:
-    service = ProvidersService(settings=settings, database=database)
-    return await service.get_provider_models(provider)
+    catalogue = ProviderModelCatalogue(settings)
+    return await catalogue.list_models_for_provider(provider)

--- a/pocketllm-backend/app/core/config.py
+++ b/pocketllm-backend/app/core/config.py
@@ -72,6 +72,16 @@ class Settings(BaseSettings):
     storage_bucket_jobs: str = "job-results"
     user_asset_bucket_name: str = "user-assets"
 
+    # Provider configuration
+    openai_api_key: str | None = Field(default=None, alias="OPENAI_API_KEY")
+    openai_api_base: str | None = Field(default=None, alias="OPENAI_API_BASE")
+    groq_api_key: str | None = Field(default=None, alias="GROQ_API_KEY")
+    groq_api_base: str | None = Field(default=None, alias="GROQ_API_BASE")
+    openrouter_api_key: str | None = Field(default=None, alias="OPENROUTER_API_KEY")
+    openrouter_api_base: str | None = Field(default=None, alias="OPENROUTER_API_BASE")
+    openrouter_app_url: str | None = Field(default=None, alias="OPENROUTER_APP_URL")
+    openrouter_app_name: str | None = Field(default=None, alias="OPENROUTER_APP_NAME")
+
 
 @lru_cache
 def get_settings() -> Settings:

--- a/pocketllm-backend/app/schemas/models.py
+++ b/pocketllm-backend/app/schemas/models.py
@@ -39,27 +39,6 @@ class ModelConfiguration(BaseModel):
     updated_at: datetime
 
 
-class ModelCreateRequest(BaseModel):
-    """Create a custom model configuration."""
-
-    provider: str
-    model: str
-    name: str
-    display_name: Optional[str] = None
-    description: Optional[str] = None
-    settings: ModelSettings = Field(default_factory=ModelSettings)
-
-
-class ModelUpdateRequest(BaseModel):
-    """Update an existing model configuration."""
-
-    name: Optional[str] = None
-    display_name: Optional[str] = None
-    description: Optional[str] = None
-    settings: Optional[ModelSettings] = None
-    is_active: Optional[bool] = None
-
-
 class ModelImportRequest(BaseModel):
     """Import provider models."""
 
@@ -77,8 +56,6 @@ class ModelDefaultRequest(BaseModel):
 __all__ = [
     "ModelSettings",
     "ModelConfiguration",
-    "ModelCreateRequest",
-    "ModelUpdateRequest",
     "ModelImportRequest",
     "ModelDefaultRequest",
 ]

--- a/pocketllm-backend/app/schemas/providers.py
+++ b/pocketllm-backend/app/schemas/providers.py
@@ -12,11 +12,15 @@ from pydantic import BaseModel, Field
 class ProviderModel(BaseModel):
     """Available provider model metadata."""
 
+    provider: str
     id: str
     name: str
+    description: Optional[str] = None
     context_window: int | None = None
     max_output_tokens: int | None = None
     pricing: dict | None = None
+    is_active: Optional[bool] = None
+    metadata: dict | None = None
 
 
 class ProviderConfiguration(BaseModel):

--- a/pocketllm-backend/app/services/__init__.py
+++ b/pocketllm-backend/app/services/__init__.py
@@ -4,7 +4,8 @@ from .auth import AuthService
 from .chats import ChatsService
 from .jobs import JobsService
 from .models import ModelsService
-from .providers import ProvidersService
+from .provider_configs import ProvidersService
+from .providers import ProviderModelCatalogue
 from .users import UsersService
 
 __all__ = [
@@ -13,5 +14,6 @@ __all__ = [
     "JobsService",
     "ModelsService",
     "ProvidersService",
+    "ProviderModelCatalogue",
     "UsersService",
 ]

--- a/pocketllm-backend/app/services/models.py
+++ b/pocketllm-backend/app/services/models.py
@@ -8,13 +8,12 @@ from uuid import UUID
 from fastapi import HTTPException, status
 
 from app.core.database import Database
+from database import ModelConfigRecord
 from app.schemas.models import (
     ModelConfiguration,
-    ModelCreateRequest,
     ModelDefaultRequest,
     ModelImportRequest,
     ModelSettings,
-    ModelUpdateRequest,
 )
 
 
@@ -41,53 +40,6 @@ class ModelsService:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Model not found")
         return self._record_to_model(record)
 
-    async def create_model(self, user_id: UUID, payload: ModelCreateRequest) -> ModelConfiguration:
-        record = await self._database.fetchrow(
-            """
-            INSERT INTO public.model_configs (user_id, provider, model, name, display_name, description, settings)
-            VALUES ($1, $2, $3, $4, $5, $6, $7)
-            RETURNING *
-            """,
-            user_id,
-            payload.provider,
-            payload.model,
-            payload.name,
-            payload.display_name,
-            payload.description,
-            payload.settings.model_dump(),
-        )
-        if not record:
-            raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to create model configuration")
-        return self._record_to_model(record)
-
-    async def update_model(self, user_id: UUID, model_id: UUID, payload: ModelUpdateRequest) -> ModelConfiguration:
-        updates: dict[str, Any] = {}
-        if payload.name is not None:
-            updates["name"] = payload.name
-        if payload.display_name is not None:
-            updates["display_name"] = payload.display_name
-        if payload.description is not None:
-            updates["description"] = payload.description
-        if payload.is_active is not None:
-            updates["is_active"] = payload.is_active
-        if payload.settings is not None:
-            updates["settings"] = payload.settings.model_dump()
-        if not updates:
-            return await self.get_model(user_id, model_id)
-
-        set_clause = ", ".join(f"{column} = ${idx}" for idx, column in enumerate(updates, start=3))
-        query = f"""
-        UPDATE public.model_configs
-        SET {set_clause}, updated_at = NOW()
-        WHERE user_id = $1 AND id = $2
-        RETURNING *
-        """
-        values: list[Any] = [user_id, model_id, *updates.values()]
-        record = await self._database.fetchrow(query, *values)
-        if not record:
-            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Model not found")
-        return self._record_to_model(record)
-
     async def delete_model(self, user_id: UUID, model_id: UUID) -> None:
         result = await self._database.execute(
             "DELETE FROM public.model_configs WHERE user_id = $1 AND id = $2",
@@ -102,14 +54,18 @@ class ModelsService:
         models = payload.models or []
         created_models: list[ModelConfiguration] = []
         for model_name in models:
-            request = ModelCreateRequest(
-                provider=payload.provider,
-                model=model_name,
-                name=model_name,
-                display_name=model_name.replace("-", " ").title(),
-                settings=ModelSettings(),
+            settings = ModelSettings()
+            created_models.append(
+                await self._insert_model_configuration(
+                    user_id=user_id,
+                    provider=payload.provider,
+                    model=model_name,
+                    name=model_name,
+                    display_name=model_name.replace("-", " ").title(),
+                    description=None,
+                    settings=settings,
+                )
             )
-            created_models.append(await self.create_model(user_id, request))
         return created_models
 
     async def set_default_model(self, user_id: UUID, model_id: UUID, payload: ModelDefaultRequest) -> ModelConfiguration:
@@ -135,8 +91,40 @@ class ModelsService:
 
     def _record_to_model(self, record: Any) -> ModelConfiguration:
         data = dict(record)
-        data["settings"] = ModelSettings.model_validate(data.get("settings") or {})
-        return ModelConfiguration.model_validate(data)
+        model_record = ModelConfigRecord.from_mapping(data)
+        return model_record.to_schema()
+
+    async def _insert_model_configuration(
+        self,
+        *,
+        user_id: UUID,
+        provider: str,
+        model: str,
+        name: str,
+        display_name: str | None,
+        description: str | None,
+        settings: ModelSettings,
+    ) -> ModelConfiguration:
+        record = await self._database.fetchrow(
+            """
+            INSERT INTO public.model_configs (user_id, provider, model, name, display_name, description, settings)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
+            RETURNING *
+            """,
+            user_id,
+            provider,
+            model,
+            name,
+            display_name,
+            description,
+            settings.model_dump(),
+        )
+        if not record:
+            raise HTTPException(
+                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                detail="Failed to create model configuration",
+            )
+        return self._record_to_model(record)
 
 
 __all__ = ["ModelsService"]

--- a/pocketllm-backend/app/services/provider_configs.py
+++ b/pocketllm-backend/app/services/provider_configs.py
@@ -9,6 +9,7 @@ from fastapi import HTTPException, status
 
 from app.core.config import Settings
 from app.core.database import Database
+from database import ProviderRecord
 from app.schemas.providers import (
     ProviderActivationRequest,
     ProviderActivationResponse,
@@ -16,22 +17,30 @@ from app.schemas.providers import (
     ProviderModel,
     ProviderUpdateRequest,
 )
+from app.services.providers import ProviderModelCatalogue
 from app.utils.security import hash_secret, mask_secret
 
 
 class ProvidersService:
     """Manage provider credentials and metadata."""
 
-    def __init__(self, settings: Settings, database: Database) -> None:
+    def __init__(
+        self,
+        settings: Settings,
+        database: Database,
+        *,
+        catalogue: ProviderModelCatalogue | None = None,
+    ) -> None:
         self._settings = settings
         self._database = database
+        self._catalogue = catalogue or ProviderModelCatalogue(settings)
 
     async def list_providers(self, user_id: UUID) -> list[ProviderConfiguration]:
         records = await self._database.fetch(
             "SELECT * FROM public.providers WHERE user_id = $1 ORDER BY created_at DESC",
             user_id,
         )
-        return [ProviderConfiguration.model_validate(dict(record)) for record in records]
+        return [ProviderRecord.from_mapping(dict(record)).to_schema() for record in records]
 
     async def activate_provider(
         self,
@@ -62,7 +71,8 @@ class ProvidersService:
         )
         if not record:
             raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="Failed to save provider")
-        return ProviderActivationResponse(provider=ProviderConfiguration.model_validate(dict(record)))
+        provider = ProviderRecord.from_mapping(dict(record)).to_schema()
+        return ProviderActivationResponse(provider=provider)
 
     async def update_provider(self, user_id: UUID, provider: str, payload: ProviderUpdateRequest) -> ProviderConfiguration:
         updates: dict[str, Any] = {k: v for k, v in payload.model_dump().items() if v is not None}
@@ -77,7 +87,7 @@ class ProvidersService:
             )
             if not record:
                 raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not found")
-            return ProviderConfiguration.model_validate(dict(record))
+            return ProviderRecord.from_mapping(dict(record)).to_schema()
 
         set_clause = ", ".join(f"{column} = ${idx}" for idx, column in enumerate(updates, start=3))
         query = f"""
@@ -90,7 +100,7 @@ class ProvidersService:
         record = await self._database.fetchrow(query, *values)
         if not record:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not found")
-        return ProviderConfiguration.model_validate(dict(record))
+        return ProviderRecord.from_mapping(dict(record)).to_schema()
 
     async def deactivate_provider(self, user_id: UUID, provider: str) -> None:
         result = await self._database.execute(
@@ -103,17 +113,7 @@ class ProvidersService:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Provider not found")
 
     async def get_provider_models(self, provider: str) -> list[ProviderModel]:
-        catalogue = {
-            "openai": [
-                ProviderModel(id="gpt-4o", name="GPT-4o", context_window=128000),
-                ProviderModel(id="gpt-4o-mini", name="GPT-4o Mini", context_window=64000),
-            ],
-            "anthropic": [
-                ProviderModel(id="claude-3-opus", name="Claude 3 Opus", context_window=200000),
-                ProviderModel(id="claude-3-haiku", name="Claude 3 Haiku", context_window=200000),
-            ],
-        }
-        return catalogue.get(provider, [])
+        return await self._catalogue.list_models_for_provider(provider)
 
 
 __all__ = ["ProvidersService"]

--- a/pocketllm-backend/app/services/providers/__init__.py
+++ b/pocketllm-backend/app/services/providers/__init__.py
@@ -1,0 +1,15 @@
+"""Provider client implementations and catalogue aggregation."""
+
+from .base import ProviderClient
+from .catalogue import ProviderModelCatalogue
+from .groq import GroqProviderClient
+from .openai import OpenAIProviderClient
+from .openrouter import OpenRouterProviderClient
+
+__all__ = [
+    "ProviderClient",
+    "ProviderModelCatalogue",
+    "GroqProviderClient",
+    "OpenAIProviderClient",
+    "OpenRouterProviderClient",
+]

--- a/pocketllm-backend/app/services/providers/base.py
+++ b/pocketllm-backend/app/services/providers/base.py
@@ -1,0 +1,114 @@
+"""Base classes for provider model catalogue clients."""
+
+from __future__ import annotations
+
+import json
+import logging
+from abc import ABC, abstractmethod
+from typing import Any
+
+import httpx
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+
+
+class ProviderClient(ABC):
+    """Abstract base class for provider specific client integrations."""
+
+    provider: str
+    default_base_url: str
+    models_endpoint: str = "/models"
+    timeout: float = 15.0
+    requires_api_key: bool = True
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        self._settings = settings
+        self._transport = transport
+        self._logger = logging.getLogger(f"app.services.providers.{self.provider}")
+
+    @property
+    def base_url(self) -> str:
+        """Return the base URL for the provider API."""
+
+        return self.default_base_url
+
+    def _build_headers(self) -> dict[str, str] | None:
+        """Return HTTP headers for the provider request."""
+
+        api_key = self._get_api_key()
+        if self.requires_api_key and not api_key:
+            return None
+        headers: dict[str, str] = {"Accept": "application/json"}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        headers.update(self._additional_headers())
+        return headers
+
+    async def list_models(self) -> list[ProviderModel]:
+        """Return the list of models provided by the provider."""
+
+        headers = self._build_headers()
+        if headers is None:
+            self._logger.warning("Skipping %s provider because credentials are not configured", self.provider)
+            return []
+
+        try:
+            payload = await self._fetch_payload(headers)
+        except httpx.HTTPStatusError as exc:
+            self._logger.error(
+                "Provider %s responded with HTTP %s: %s",
+                self.provider,
+                exc.response.status_code,
+                exc.response.text,
+            )
+            return []
+        except httpx.HTTPError as exc:
+            self._logger.error("Provider %s request failed: %s", self.provider, exc)
+            return []
+        except Exception:  # pragma: no cover - defensive catch-all
+            self._logger.exception("Unexpected error while fetching models from %s", self.provider)
+            return []
+
+        try:
+            models = self._parse_models(payload)
+        except Exception:  # pragma: no cover - defensive catch-all
+            self._logger.exception("Failed to parse model catalogue response from %s", self.provider)
+            return []
+        return models
+
+    async def _fetch_payload(self, headers: dict[str, str]) -> Any:
+        """Execute the HTTP request and return the response payload."""
+
+        async with httpx.AsyncClient(
+            base_url=self.base_url,
+            headers=headers,
+            timeout=self.timeout,
+            transport=self._transport,
+        ) as client:
+            response = await client.get(self.models_endpoint)
+            response.raise_for_status()
+            if response.headers.get("content-type", "").startswith("application/json"):
+                return response.json()
+            return json.loads(response.text)
+
+    def _additional_headers(self) -> dict[str, str]:
+        """Return additional provider specific headers."""
+
+        return {}
+
+    @abstractmethod
+    def _get_api_key(self) -> str | None:
+        """Return the provider API key if configured."""
+
+    @abstractmethod
+    def _parse_models(self, payload: Any) -> list[ProviderModel]:
+        """Convert the provider response payload into provider models."""
+
+
+__all__ = ["ProviderClient"]

--- a/pocketllm-backend/app/services/providers/catalogue.py
+++ b/pocketllm-backend/app/services/providers/catalogue.py
@@ -1,0 +1,77 @@
+"""Aggregation utilities for provider model catalogues."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Iterable, Sequence
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+
+from .base import ProviderClient
+from .groq import GroqProviderClient
+from .openai import OpenAIProviderClient
+from .openrouter import OpenRouterProviderClient
+
+
+class ProviderModelCatalogue:
+    """Aggregate models across multiple provider clients."""
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        clients: Iterable[ProviderClient] | None = None,
+    ) -> None:
+        self._settings = settings
+        self._clients_override = list(clients) if clients is not None else None
+        self._logger = logging.getLogger("app.services.providers.catalogue")
+
+    async def list_all_models(self) -> list[ProviderModel]:
+        """Return models from every configured provider."""
+
+        clients = self._get_clients()
+        return await self._gather_models(clients)
+
+    async def list_models_for_provider(self, provider: str) -> list[ProviderModel]:
+        """Return models for a single provider if supported."""
+
+        provider_key = provider.lower()
+        clients = [client for client in self._get_clients() if client.provider == provider_key]
+        if not clients:
+            self._logger.warning("Requested unsupported provider catalogue: %s", provider)
+            return []
+        return await self._gather_models(clients)
+
+    def _get_clients(self) -> list[ProviderClient]:
+        if self._clients_override is not None:
+            return list(self._clients_override)
+        return [
+            OpenAIProviderClient(self._settings),
+            GroqProviderClient(self._settings),
+            OpenRouterProviderClient(self._settings),
+        ]
+
+    async def _gather_models(self, clients: Sequence[ProviderClient]) -> list[ProviderModel]:
+        if not clients:
+            return []
+        tasks = [self._safe_list_models(client) for client in clients]
+        results = await asyncio.gather(*tasks)
+        models: list[ProviderModel] = []
+        for provider_models in results:
+            models.extend(provider_models)
+        return models
+
+    async def _safe_list_models(self, client: ProviderClient) -> list[ProviderModel]:
+        try:
+            models = await client.list_models()
+        except Exception:  # pragma: no cover - defensive catch-all
+            self._logger.exception("Failed to fetch models from provider %s", client.provider)
+            return []
+        if not models:
+            self._logger.info("Provider %s returned no models or is not configured", client.provider)
+        return models
+
+
+__all__ = ["ProviderModelCatalogue"]

--- a/pocketllm-backend/app/services/providers/groq.py
+++ b/pocketllm-backend/app/services/providers/groq.py
@@ -1,0 +1,71 @@
+"""Groq provider client implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+
+from .base import ProviderClient
+
+
+class GroqProviderClient(ProviderClient):
+    """Fetch available models from Groq Cloud."""
+
+    provider = "groq"
+    default_base_url = "https://api.groq.com/openai/v1"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        super().__init__(settings, transport=transport)
+
+    @property
+    def base_url(self) -> str:
+        api_base = getattr(self._settings, "groq_api_base", None)
+        return api_base or self.default_base_url
+
+    def _get_api_key(self) -> str | None:  # pragma: no cover - simple accessor
+        return getattr(self._settings, "groq_api_key", None)
+
+    def _parse_models(self, payload: Any) -> list[ProviderModel]:
+        data = payload.get("data", []) if isinstance(payload, dict) else []
+        models: list[ProviderModel] = []
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            model_id = entry.get("id")
+            if not model_id:
+                continue
+            name = entry.get("name") or model_id
+            metadata_keys = (
+                "type",
+                "owned_by",
+                "permissions",
+                "support_disclaimer",
+                "capabilities",
+            )
+            metadata = {key: entry.get(key) for key in metadata_keys if entry.get(key) is not None}
+            models.append(
+                ProviderModel(
+                    provider=self.provider,
+                    id=model_id,
+                    name=name,
+                    description=entry.get("description"),
+                    context_window=entry.get("context_window"),
+                    max_output_tokens=entry.get("max_output_tokens"),
+                    pricing=entry.get("pricing"),
+                    is_active=entry.get("active"),
+                    metadata=metadata or None,
+                )
+            )
+        return models
+
+
+__all__ = ["GroqProviderClient"]

--- a/pocketllm-backend/app/services/providers/openai.py
+++ b/pocketllm-backend/app/services/providers/openai.py
@@ -1,0 +1,70 @@
+"""OpenAI provider client implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+
+from .base import ProviderClient
+
+
+class OpenAIProviderClient(ProviderClient):
+    """Fetch models from the OpenAI platform."""
+
+    provider = "openai"
+    default_base_url = "https://api.openai.com/v1"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        super().__init__(settings, transport=transport)
+
+    @property
+    def base_url(self) -> str:
+        api_base = getattr(self._settings, "openai_api_base", None)
+        return api_base or self.default_base_url
+
+    def _get_api_key(self) -> str | None:  # pragma: no cover - simple accessor
+        return getattr(self._settings, "openai_api_key", None)
+
+    def _parse_models(self, payload: Any) -> list[ProviderModel]:
+        data = payload.get("data", []) if isinstance(payload, dict) else []
+        models: list[ProviderModel] = []
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            model_id = entry.get("id")
+            if not model_id:
+                continue
+            name = entry.get("name") or model_id
+            context_window = entry.get("context_window") or entry.get("context_length")
+            max_output_tokens = entry.get("max_output_tokens") or entry.get("max_tokens")
+            metadata = {
+                key: entry.get(key)
+                for key in ("object", "created", "owned_by", "permission")
+                if entry.get(key) is not None
+            }
+            models.append(
+                ProviderModel(
+                    provider=self.provider,
+                    id=model_id,
+                    name=name,
+                    description=entry.get("description"),
+                    context_window=context_window,
+                    max_output_tokens=max_output_tokens,
+                    pricing=None,
+                    is_active=entry.get("status"),
+                    metadata=metadata or None,
+                )
+            )
+        return models
+
+
+__all__ = ["OpenAIProviderClient"]

--- a/pocketllm-backend/app/services/providers/openrouter.py
+++ b/pocketllm-backend/app/services/providers/openrouter.py
@@ -1,0 +1,88 @@
+"""OpenRouter provider client implementation."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+
+from .base import ProviderClient
+
+
+class OpenRouterProviderClient(ProviderClient):
+    """Fetch available models through the OpenRouter catalogue."""
+
+    provider = "openrouter"
+    default_base_url = "https://openrouter.ai/api/v1"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        super().__init__(settings, transport=transport)
+
+    @property
+    def base_url(self) -> str:
+        api_base = getattr(self._settings, "openrouter_api_base", None)
+        return api_base or self.default_base_url
+
+    def _get_api_key(self) -> str | None:  # pragma: no cover - simple accessor
+        return getattr(self._settings, "openrouter_api_key", None)
+
+    def _additional_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        app_url = getattr(self._settings, "openrouter_app_url", None)
+        if app_url:
+            headers["HTTP-Referer"] = app_url
+        app_name = getattr(self._settings, "openrouter_app_name", None)
+        if app_name:
+            headers["X-Title"] = app_name
+        return headers
+
+    def _parse_models(self, payload: Any) -> list[ProviderModel]:
+        data = payload.get("data", []) if isinstance(payload, dict) else []
+        models: list[ProviderModel] = []
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            model_id = entry.get("id")
+            if not model_id:
+                continue
+            name = entry.get("name") or model_id
+            context_window = entry.get("context_length") or entry.get("context_window")
+            pricing = entry.get("pricing")
+            top_provider = entry.get("top_provider")
+            if not isinstance(top_provider, dict):
+                top_provider = None
+            max_output_tokens = None
+            if isinstance(top_provider, dict):
+                max_output_tokens = top_provider.get("max_output_tokens")
+            metadata = {
+                key: entry.get(key)
+                for key in ("description", "architecture", "display_name", "provider", "families", "tags")
+                if entry.get(key) is not None
+            }
+            if top_provider:
+                metadata.setdefault("top_provider", top_provider)
+            models.append(
+                ProviderModel(
+                    provider=self.provider,
+                    id=model_id,
+                    name=name,
+                    description=entry.get("description"),
+                    context_window=context_window,
+                    max_output_tokens=max_output_tokens,
+                    pricing=pricing,
+                    is_active=entry.get("status") or entry.get("enabled"),
+                    metadata=metadata or None,
+                )
+            )
+        return models
+
+
+__all__ = ["OpenRouterProviderClient"]

--- a/pocketllm-backend/database/__init__.py
+++ b/pocketllm-backend/database/__init__.py
@@ -1,0 +1,5 @@
+"""Database model abstractions for the PocketLLM backend."""
+
+from .database_model import ModelConfigRecord, ProviderRecord
+
+__all__ = ["ModelConfigRecord", "ProviderRecord"]

--- a/pocketllm-backend/database/database_model.py
+++ b/pocketllm-backend/database/database_model.py
@@ -1,0 +1,118 @@
+"""Dataclasses representing rows from persistent storage."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Mapping
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class ProviderRecord:
+    """In-memory representation of a provider configuration row."""
+
+    id: UUID
+    user_id: UUID
+    provider: str
+    display_name: str | None
+    base_url: str | None
+    metadata: dict | None
+    api_key_hash: str | None
+    api_key_preview: str | None
+    is_active: bool
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ProviderRecord":
+        return cls(
+            id=data["id"],
+            user_id=data["user_id"],
+            provider=data["provider"],
+            display_name=data.get("display_name"),
+            base_url=data.get("base_url"),
+            metadata=dict(data.get("metadata") or {}),
+            api_key_hash=data.get("api_key_hash"),
+            api_key_preview=data.get("api_key_preview"),
+            is_active=bool(data.get("is_active", False)),
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+        )
+
+    def to_schema(self):  # pragma: no cover - thin wrapper
+        from app.schemas.providers import ProviderConfiguration
+
+        return ProviderConfiguration.model_validate(
+            {
+                "id": self.id,
+                "user_id": self.user_id,
+                "provider": self.provider,
+                "display_name": self.display_name,
+                "base_url": self.base_url,
+                "metadata": self.metadata,
+                "api_key_preview": self.api_key_preview,
+                "is_active": self.is_active,
+                "created_at": self.created_at,
+                "updated_at": self.updated_at,
+            }
+        )
+
+
+@dataclass(frozen=True)
+class ModelConfigRecord:
+    """In-memory representation of a model configuration row."""
+
+    id: UUID
+    user_id: UUID
+    provider_id: UUID | None
+    provider: str
+    model: str
+    name: str
+    display_name: str | None
+    description: str | None
+    is_default: bool
+    is_active: bool
+    settings: dict
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "ModelConfigRecord":
+        return cls(
+            id=data["id"],
+            user_id=data["user_id"],
+            provider_id=data.get("provider_id"),
+            provider=data["provider"],
+            model=data["model"],
+            name=data["name"],
+            display_name=data.get("display_name"),
+            description=data.get("description"),
+            is_default=bool(data.get("is_default", False)),
+            is_active=bool(data.get("is_active", True)),
+            settings=dict(data.get("settings") or {}),
+            created_at=data["created_at"],
+            updated_at=data["updated_at"],
+        )
+
+    def to_schema(self):  # pragma: no cover - thin wrapper
+        from app.schemas.models import ModelConfiguration, ModelSettings
+
+        return ModelConfiguration(
+            id=self.id,
+            user_id=self.user_id,
+            provider_id=self.provider_id,
+            provider=self.provider,
+            model=self.model,
+            name=self.name,
+            display_name=self.display_name,
+            description=self.description,
+            is_default=self.is_default,
+            is_active=self.is_active,
+            settings=ModelSettings.model_validate(self.settings),
+            created_at=self.created_at,
+            updated_at=self.updated_at,
+        )
+
+
+__all__ = ["ProviderRecord", "ModelConfigRecord"]

--- a/pocketllm-backend/tests/test_provider_catalogue.py
+++ b/pocketllm-backend/tests/test_provider_catalogue.py
@@ -1,0 +1,120 @@
+import asyncio
+
+import httpx
+import pytest
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+from app.services.providers import (
+    GroqProviderClient,
+    OpenAIProviderClient,
+    OpenRouterProviderClient,
+    ProviderModelCatalogue,
+)
+
+
+class StubProviderClient:
+    def __init__(self, provider: str, models: list[ProviderModel] | None = None, error: Exception | None = None):
+        self.provider = provider
+        self._models = models or []
+        self._error = error
+
+    async def list_models(self) -> list[ProviderModel]:
+        if self._error:
+            raise self._error
+        await asyncio.sleep(0)
+        return self._models
+
+
+@pytest.mark.asyncio
+async def test_catalogue_aggregates_models():
+    settings = Settings()
+    openai_model = ProviderModel(provider="openai", id="gpt-4o", name="GPT-4o")
+    groq_model = ProviderModel(provider="groq", id="llama", name="Llama")
+    catalogue = ProviderModelCatalogue(settings, clients=[
+        StubProviderClient("openai", [openai_model]),
+        StubProviderClient("groq", [groq_model]),
+    ])
+
+    models = await catalogue.list_all_models()
+
+    assert {model.id for model in models} == {"gpt-4o", "llama"}
+    assert {model.provider for model in models} == {"openai", "groq"}
+
+
+@pytest.mark.asyncio
+async def test_catalogue_filters_by_provider():
+    settings = Settings()
+    catalogue = ProviderModelCatalogue(settings, clients=[
+        StubProviderClient("openai", [ProviderModel(provider="openai", id="gpt", name="GPT")]),
+        StubProviderClient("groq", [ProviderModel(provider="groq", id="groq-1", name="Groq")]),
+    ])
+
+    groq_models = await catalogue.list_models_for_provider("groq")
+
+    assert len(groq_models) == 1
+    assert groq_models[0].provider == "groq"
+    assert groq_models[0].id == "groq-1"
+
+
+@pytest.mark.asyncio
+async def test_catalogue_handles_provider_errors(caplog):
+    settings = Settings()
+    catalogue = ProviderModelCatalogue(settings, clients=[
+        StubProviderClient("openrouter", error=RuntimeError("boom"))
+    ])
+
+    with caplog.at_level("ERROR"):
+        models = await catalogue.list_all_models()
+
+    assert models == []
+    assert any("openrouter" in message for message in caplog.text.splitlines())
+
+
+@pytest.mark.asyncio
+async def test_openai_provider_client_parses_response():
+    async def handler(request: httpx.Request) -> httpx.Response:  # pragma: no cover - simple mock
+        assert request.headers["Authorization"].startswith("Bearer test-key")
+        payload = {"data": [{"id": "gpt-test", "name": "GPT Test", "context_window": 1024}]}
+        return httpx.Response(status_code=200, json=payload)
+
+    settings = Settings(openai_api_key="test-key")
+    client = OpenAIProviderClient(settings, transport=httpx.MockTransport(handler))
+
+    models = await client.list_models()
+
+    assert len(models) == 1
+    model = models[0]
+    assert model.provider == "openai"
+    assert model.id == "gpt-test"
+    assert model.context_window == 1024
+
+
+@pytest.mark.asyncio
+async def test_groq_provider_client_requires_api_key():
+    settings = Settings()
+    client = GroqProviderClient(settings)
+
+    models = await client.list_models()
+
+    assert models == []
+
+
+@pytest.mark.asyncio
+async def test_openrouter_provider_client_includes_headers():
+    async def handler(request: httpx.Request) -> httpx.Response:
+        assert request.headers["Authorization"].startswith("Bearer router-key")
+        assert request.headers["HTTP-Referer"] == "https://example.com"
+        assert request.headers["X-Title"] == "PocketLLM"
+        return httpx.Response(status_code=200, json={"data": []})
+
+    settings = Settings(
+        openrouter_api_key="router-key",
+        openrouter_app_url="https://example.com",
+        openrouter_app_name="PocketLLM",
+    )
+    client = OpenRouterProviderClient(settings, transport=httpx.MockTransport(handler))
+
+    models = await client.list_models()
+
+    assert models == []


### PR DESCRIPTION
## Summary
- replace the `GET /v1/models` handler with a provider catalogue that queries Groq, OpenAI, and OpenRouter APIs while moving saved configurations to `/v1/models/saved`
- add provider-specific client modules, a shared catalogue service, updated schemas/settings, and database record helpers to normalise provider/model data
- refresh API documentation and provider services to use the new aggregation flow and include a dedicated test suite for the catalogue

## Testing
- pytest *(fails: missing fastapi/pydantic/httpx dependencies; pip install blocked by proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68d683ecfbec832d82ec06d694bc1998