### PR TITLE
Fix Supabase REST fallback initialization

### DIFF
--- a/pocketllm-backend/app/core/database.py
+++ b/pocketllm-backend/app/core/database.py
@@ -207,7 +207,8 @@ class _SupabaseRestStore:
 
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
-        self._base_url = settings.supabase_url.rstrip("/") + "/rest/v1"
+        supabase_url = str(settings.supabase_url)
+        self._base_url = supabase_url.rstrip("/") + "/rest/v1"
         self._headers = {
             "apikey": settings.supabase_service_role_key,
             "Authorization": f"Bearer {settings.supabase_service_role_key}",


### PR DESCRIPTION
## Summary
- ensure the Supabase REST fallback store normalises the configured URL before appending the REST path so AnyHttpUrl settings work at runtime

## Testing
- pytest *(fails: missing backend dependencies such as fastapi and pydantic in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b13fe6f8832db1e7b9797b8645fd