### PR TITLE
Improve Supabase REST profile upsert handling

### DIFF
--- a/pocketllm-backend/app/core/database.py
+++ b/pocketllm-backend/app/core/database.py
@@ -207,7 +207,8 @@ class _SupabaseRestStore:
 
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
-        self._base_url = settings.supabase_url.rstrip("/") + "/rest/v1"
+        supabase_url = str(settings.supabase_url)
+        self._base_url = supabase_url.rstrip("/") + "/rest/v1"
         self._headers = {
             "apikey": settings.supabase_service_role_key,
             "Authorization": f"Bearer {settings.supabase_service_role_key}",
@@ -314,19 +315,42 @@ class _SupabaseRestStore:
         columns_section = query.split("(", 1)[1].split(")", 1)[0]
         column_names = [column.strip() for column in columns_section.split(",") if column.strip()]
         values = dict(zip(column_names, args))
-        payload = self._serialise_payload(values)
-        user_id = payload.get("id")
+        user_id = values.get("id")
+        existing: dict[str, Any] | None = None
         if user_id:
-            existing = await self._get_profile(UUID(str(user_id)))
-            if existing and payload.get("full_name") is None:
-                payload.pop("full_name", None)
+            user_uuid = UUID(str(user_id))
+            existing = await self._get_profile(user_uuid)
+        else:
+            user_uuid = None
+
+        if existing and values.get("full_name") is None and existing.get("full_name"):
+            values.pop("full_name", None)
+
+        now = datetime.now(tz=UTC)
+        if existing:
+            values.pop("created_at", None)
+            values.pop("id", None)
+            values["updated_at"] = now
+            payload = self._serialise_payload(values)
+            payload = {k: v for k, v in payload.items() if v is not None}
+            await self._request(
+                "PATCH",
+                "profiles",
+                params={"id": f"eq.{user_uuid}"},
+                json_payload=payload,
+                prefer="return=minimal",
+            )
+            return
+
+        values.setdefault("created_at", now)
+        values.setdefault("updated_at", now)
+        payload = self._serialise_payload(values)
         payload = {k: v for k, v in payload.items() if v is not None}
         await self._request(
             "POST",
             "profiles",
-            params={"on_conflict": "id"},
-            json_payload=[payload],
-            prefer="resolution=merge-duplicates",
+            json_payload=payload,
+            prefer="return=minimal",
         )
 
     async def _handle_update(self, query: str, *args: Any) -> dict[str, Any] | None:

--- a/pocketllm-backend/tests/test_database_supabase_rest.py
+++ b/pocketllm-backend/tests/test_database_supabase_rest.py
@@ -1,0 +1,105 @@
+"""Tests for the Supabase REST fallback store."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+from app.core.config import Settings
+from app.core.database import _SupabaseRestStore
+
+
+@pytest.mark.asyncio
+async def test_upsert_profile_creates_new_record(monkeypatch):
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_service_role_key="service-role-test-key",
+    )
+    store = _SupabaseRestStore(settings)
+
+    captured: dict[str, object] = {}
+
+    async def fake_get_profile(user_id: UUID):  # pragma: no cover - patched in test
+        captured["looked_up"] = user_id
+        return None
+
+    async def fake_request(method: str, resource: str, **kwargs):  # pragma: no cover - patched in test
+        captured["method"] = method
+        captured["resource"] = resource
+        captured["kwargs"] = kwargs
+        return None
+
+    monkeypatch.setattr(store, "_get_profile", fake_get_profile)
+    monkeypatch.setattr(store, "_request", fake_request)
+
+    user_id = UUID("8fcae76c-1114-4147-b519-b87154abcf35")
+    query = """
+    INSERT INTO public.profiles (id, email, full_name)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        full_name = COALESCE(EXCLUDED.full_name, public.profiles.full_name)
+    """
+
+    await store._upsert_profile(query, user_id, "user@example.com", "Test User")
+
+    assert captured["method"] == "POST"
+    assert captured["resource"] == "profiles"
+    kwargs = captured["kwargs"]
+    assert kwargs["prefer"] == "return=minimal"
+    assert kwargs.get("params") is None
+    payload = kwargs["json_payload"]
+    assert payload["id"] == str(user_id)
+    assert payload["email"] == "user@example.com"
+    assert payload["full_name"] == "Test User"
+    assert "created_at" in payload
+    assert "updated_at" in payload
+
+
+@pytest.mark.asyncio
+async def test_upsert_profile_updates_existing_record(monkeypatch):
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_service_role_key="service-role-test-key",
+    )
+    store = _SupabaseRestStore(settings)
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_get_profile(user_id: UUID):  # pragma: no cover - patched in test
+        return {"id": str(user_id), "full_name": "Existing Name"}
+
+    async def fake_request(method: str, resource: str, **kwargs):  # pragma: no cover - patched in test
+        calls.append({"method": method, "resource": resource, "kwargs": kwargs})
+        return None
+
+    monkeypatch.setattr(store, "_get_profile", fake_get_profile)
+    monkeypatch.setattr(store, "_request", fake_request)
+
+    user_id = UUID("11111111-2222-3333-4444-555555555555")
+    query = """
+    INSERT INTO public.profiles (id, email, full_name)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        full_name = COALESCE(EXCLUDED.full_name, public.profiles.full_name)
+    """
+
+    await store._upsert_profile(query, user_id, "new@example.com", None)
+
+    assert calls, "Expected the Supabase REST store to issue a request"
+    call = calls[0]
+    assert call["method"] == "PATCH"
+    assert call["resource"] == "profiles"
+    kwargs = call["kwargs"]
+    assert kwargs["params"] == {"id": f"eq.{user_id}"}
+    assert kwargs["prefer"] == "return=minimal"
+    payload = kwargs["json_payload"]
+    assert payload["email"] == "new@example.com"
+    assert "id" not in payload
+    assert "created_at" not in payload
+    assert "full_name" not in payload
+    assert "updated_at" in payload
+    # Ensure the updated_at value is an ISO formatted timestamp
+    assert "T" in payload["updated_at"]


### PR DESCRIPTION
## Summary
- avoid relying on Supabase on_conflict upserts by detecting existing profiles and issuing either POST or PATCH requests explicitly
- normalise update payloads by skipping immutable fields and always refreshing timestamps to match the SQL behaviour
- add focused tests to cover the new Supabase REST profile creation and update flows

## Testing
- pytest *(fails: missing runtime dependencies such as fastapi, pydantic, and httpx in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b13fe6f8832db1e7b9797b8645fd