### PR TITLE
Handle Supabase duplicate insert conflicts

### DIFF
--- a/pocketllm-backend/app/core/database.py
+++ b/pocketllm-backend/app/core/database.py
@@ -207,7 +207,8 @@ class _SupabaseRestStore:
 
     def __init__(self, settings: Settings) -> None:
         self._settings = settings
-        self._base_url = settings.supabase_url.rstrip("/") + "/rest/v1"
+        supabase_url = str(settings.supabase_url)
+        self._base_url = supabase_url.rstrip("/") + "/rest/v1"
         self._headers = {
             "apikey": settings.supabase_service_role_key,
             "Authorization": f"Bearer {settings.supabase_service_role_key}",
@@ -314,20 +315,68 @@ class _SupabaseRestStore:
         columns_section = query.split("(", 1)[1].split(")", 1)[0]
         column_names = [column.strip() for column in columns_section.split(",") if column.strip()]
         values = dict(zip(column_names, args))
-        payload = self._serialise_payload(values)
-        user_id = payload.get("id")
+        user_id = values.get("id")
+        existing: dict[str, Any] | None = None
         if user_id:
-            existing = await self._get_profile(UUID(str(user_id)))
-            if existing and payload.get("full_name") is None:
-                payload.pop("full_name", None)
+            user_uuid = UUID(str(user_id))
+            existing = await self._get_profile(user_uuid)
+        else:
+            user_uuid = None
+
+        if existing and values.get("full_name") is None and existing.get("full_name"):
+            values.pop("full_name", None)
+
+        now = datetime.now(tz=UTC)
+        if existing:
+            update_values = dict(values)
+            update_values.pop("created_at", None)
+            update_values.pop("id", None)
+            update_values["updated_at"] = now
+            payload = self._serialise_payload(update_values)
+            payload = {k: v for k, v in payload.items() if v is not None}
+            await self._request(
+                "PATCH",
+                "profiles",
+                params={"id": f"eq.{user_uuid}"},
+                json_payload=payload,
+                prefer="return=minimal",
+            )
+            return
+
+        insert_values = dict(values)
+        insert_values.setdefault("created_at", now)
+        insert_values.setdefault("updated_at", now)
+        payload = self._serialise_payload(insert_values)
         payload = {k: v for k, v in payload.items() if v is not None}
-        await self._request(
-            "POST",
-            "profiles",
-            params={"on_conflict": "id"},
-            json_payload=[payload],
-            prefer="resolution=merge-duplicates",
-        )
+
+        try:
+            await self._request(
+                "POST",
+                "profiles",
+                json_payload=payload,
+                prefer="return=minimal",
+            )
+        except httpx.HTTPStatusError as exc:
+            if user_uuid and self._should_retry_as_update(exc):
+                self._logger.info(
+                    "Supabase profile insert detected duplicate. Retrying with PATCH.",
+                    extra={"user_id": str(user_uuid)},
+                )
+                update_values = dict(values)
+                update_values.pop("created_at", None)
+                update_values.pop("id", None)
+                update_values["updated_at"] = datetime.now(tz=UTC)
+                update_payload = self._serialise_payload(update_values)
+                update_payload = {k: v for k, v in update_payload.items() if v is not None}
+                await self._request(
+                    "PATCH",
+                    "profiles",
+                    params={"id": f"eq.{user_uuid}"},
+                    json_payload=update_payload,
+                    prefer="return=minimal",
+                )
+                return
+            raise
 
     async def _handle_update(self, query: str, *args: Any) -> dict[str, Any] | None:
         user_id = args[0]
@@ -390,6 +439,28 @@ class _SupabaseRestStore:
             else:
                 serialised[key] = value
         return serialised
+
+    def _should_retry_as_update(self, exc: httpx.HTTPStatusError) -> bool:
+        if exc.response is None:
+            return False
+        if exc.response.status_code not in {400, 409}:
+            return False
+        try:
+            data = exc.response.json()
+        except ValueError:
+            message = exc.response.text.lower()
+            return "duplicate key value" in message or "already exists" in message
+
+        def _normalise(value: Any) -> str:
+            return str(value or "").lower()
+
+        code = _normalise(data.get("code"))
+        message = _normalise(data.get("message"))
+        details = _normalise(data.get("details"))
+        combined = " ".join(part for part in (message, details) if part)
+        if code in {"23505", "pgrst204"}:
+            return True
+        return "duplicate key value" in combined or "already exists" in combined
 
     async def _request(
         self,

--- a/pocketllm-backend/app/core/database.py
+++ b/pocketllm-backend/app/core/database.py
@@ -348,13 +348,15 @@ class _SupabaseRestStore:
         insert_values.setdefault("updated_at", now)
         payload = self._serialise_payload(insert_values)
         payload = {k: v for k, v in payload.items() if v is not None}
+        prefer_header = "resolution=merge-duplicates,return=minimal"
 
         try:
             await self._request(
                 "POST",
                 "profiles",
+                params={"on_conflict": "id"},
                 json_payload=payload,
-                prefer="return=minimal",
+                prefer=prefer_header,
             )
         except httpx.HTTPStatusError as exc:
             if user_uuid and self._should_retry_as_update(exc):

--- a/pocketllm-backend/tests/test_database_supabase_rest.py
+++ b/pocketllm-backend/tests/test_database_supabase_rest.py
@@ -1,0 +1,158 @@
+"""Tests for the Supabase REST fallback store."""
+
+from __future__ import annotations
+
+from uuid import UUID
+
+import pytest
+
+httpx = pytest.importorskip("httpx")
+
+from app.core.config import Settings
+from app.core.database import _SupabaseRestStore
+
+
+@pytest.mark.asyncio
+async def test_upsert_profile_creates_new_record(monkeypatch):
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_service_role_key="service-role-test-key",
+    )
+    store = _SupabaseRestStore(settings)
+
+    captured: dict[str, object] = {}
+
+    async def fake_get_profile(user_id: UUID):  # pragma: no cover - patched in test
+        captured["looked_up"] = user_id
+        return None
+
+    async def fake_request(method: str, resource: str, **kwargs):  # pragma: no cover - patched in test
+        captured["method"] = method
+        captured["resource"] = resource
+        captured["kwargs"] = kwargs
+        return None
+
+    monkeypatch.setattr(store, "_get_profile", fake_get_profile)
+    monkeypatch.setattr(store, "_request", fake_request)
+
+    user_id = UUID("8fcae76c-1114-4147-b519-b87154abcf35")
+    query = """
+    INSERT INTO public.profiles (id, email, full_name)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        full_name = COALESCE(EXCLUDED.full_name, public.profiles.full_name)
+    """
+
+    await store._upsert_profile(query, user_id, "user@example.com", "Test User")
+
+    assert captured["method"] == "POST"
+    assert captured["resource"] == "profiles"
+    kwargs = captured["kwargs"]
+    assert kwargs["prefer"] == "return=minimal"
+    assert kwargs.get("params") is None
+    payload = kwargs["json_payload"]
+    assert payload["id"] == str(user_id)
+    assert payload["email"] == "user@example.com"
+    assert payload["full_name"] == "Test User"
+    assert "created_at" in payload
+    assert "updated_at" in payload
+
+
+@pytest.mark.asyncio
+async def test_upsert_profile_updates_existing_record(monkeypatch):
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_service_role_key="service-role-test-key",
+    )
+    store = _SupabaseRestStore(settings)
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_get_profile(user_id: UUID):  # pragma: no cover - patched in test
+        return {"id": str(user_id), "full_name": "Existing Name"}
+
+    async def fake_request(method: str, resource: str, **kwargs):  # pragma: no cover - patched in test
+        calls.append({"method": method, "resource": resource, "kwargs": kwargs})
+        return None
+
+    monkeypatch.setattr(store, "_get_profile", fake_get_profile)
+    monkeypatch.setattr(store, "_request", fake_request)
+
+    user_id = UUID("11111111-2222-3333-4444-555555555555")
+    query = """
+    INSERT INTO public.profiles (id, email, full_name)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email,
+        full_name = COALESCE(EXCLUDED.full_name, public.profiles.full_name)
+    """
+
+    await store._upsert_profile(query, user_id, "new@example.com", None)
+
+    assert calls, "Expected the Supabase REST store to issue a request"
+    call = calls[0]
+    assert call["method"] == "PATCH"
+    assert call["resource"] == "profiles"
+    kwargs = call["kwargs"]
+    assert kwargs["params"] == {"id": f"eq.{user_id}"}
+    assert kwargs["prefer"] == "return=minimal"
+    payload = kwargs["json_payload"]
+    assert payload["email"] == "new@example.com"
+    assert "id" not in payload
+    assert "created_at" not in payload
+    assert "full_name" not in payload
+    assert "updated_at" in payload
+    # Ensure the updated_at value is an ISO formatted timestamp
+    assert "T" in payload["updated_at"]
+
+
+@pytest.mark.asyncio
+async def test_upsert_profile_retries_after_duplicate_error(monkeypatch):
+    settings = Settings(
+        supabase_url="https://example.supabase.co",
+        supabase_service_role_key="service-role-test-key",
+    )
+    store = _SupabaseRestStore(settings)
+
+    calls: list[dict[str, object]] = []
+
+    async def fake_get_profile(user_id: UUID):  # pragma: no cover - patched in test
+        return None
+
+    async def fake_request(method: str, resource: str, **kwargs):  # pragma: no cover - patched in test
+        calls.append({"method": method, "resource": resource, "kwargs": kwargs})
+        if method == "POST":
+            response = httpx.Response(
+                status_code=400,
+                request=httpx.Request("POST", "https://example.supabase.co/rest/v1/profiles"),
+                json={
+                    "code": "23505",
+                    "message": 'duplicate key value violates unique constraint "profiles_pkey"',
+                    "details": "Key (id)=(8fcae76c-1114-4147-b519-b87154abcf35) already exists.",
+                },
+            )
+            raise httpx.HTTPStatusError("duplicate", request=response.request, response=response)
+        return None
+
+    monkeypatch.setattr(store, "_get_profile", fake_get_profile)
+    monkeypatch.setattr(store, "_request", fake_request)
+
+    user_id = UUID("8fcae76c-1114-4147-b519-b87154abcf35")
+    query = """
+    INSERT INTO public.profiles (id, email)
+    VALUES ($1, $2)
+    ON CONFLICT (id) DO UPDATE SET
+        email = EXCLUDED.email
+    """
+
+    await store._upsert_profile(query, user_id, "user@example.com")
+
+    assert len(calls) == 2
+    assert calls[0]["method"] == "POST"
+    assert calls[1]["method"] == "PATCH"
+    patch_kwargs = calls[1]["kwargs"]
+    assert patch_kwargs["params"] == {"id": f"eq.{user_id}"}
+    payload = patch_kwargs["json_payload"]
+    assert payload["email"] == "user@example.com"
+    assert "created_at" not in payload

--- a/pocketllm-backend/tests/test_database_supabase_rest.py
+++ b/pocketllm-backend/tests/test_database_supabase_rest.py
@@ -49,8 +49,8 @@ async def test_upsert_profile_creates_new_record(monkeypatch):
     assert captured["method"] == "POST"
     assert captured["resource"] == "profiles"
     kwargs = captured["kwargs"]
-    assert kwargs["prefer"] == "return=minimal"
-    assert kwargs.get("params") is None
+    assert kwargs["prefer"] == "resolution=merge-duplicates,return=minimal"
+    assert kwargs.get("params") == {"on_conflict": "id"}
     payload = kwargs["json_payload"]
     assert payload["id"] == str(user_id)
     assert payload["email"] == "user@example.com"
@@ -150,6 +150,9 @@ async def test_upsert_profile_retries_after_duplicate_error(monkeypatch):
 
     assert len(calls) == 2
     assert calls[0]["method"] == "POST"
+    post_kwargs = calls[0]["kwargs"]
+    assert post_kwargs["prefer"] == "resolution=merge-duplicates,return=minimal"
+    assert post_kwargs["params"] == {"on_conflict": "id"}
     assert calls[1]["method"] == "PATCH"
     patch_kwargs = calls[1]["kwargs"]
     assert patch_kwargs["params"] == {"id": f"eq.{user_id}"}


### PR DESCRIPTION
## Summary
- retry Supabase REST profile inserts as targeted patches when duplicate-key errors are returned
- log duplicate detection and reuse update serialization so immutable fields stay untouched
- extend the Supabase REST store tests with coverage for duplicate insert handling while gracefully skipping when httpx is unavailable

## Testing
- pytest tests/test_database_supabase_rest.py *(fails: missing httpx dependency in the execution environment, tests skipped)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b13fe6f8832db1e7b9797b8645fd