### PR TITLE
Document frontend hardcoding and annotate files

### DIFF
--- a/docs/frontend_cleanup_tasks.md
+++ b/docs/frontend_cleanup_tasks.md
@@ -1,0 +1,65 @@
+# Frontend Cleanup Task List
+
+This document enumerates the hardcoded or client-owned behaviors in the current Flutter
+frontend and outlines the backend-first refactor work required to finish the migration.
+Items are grouped by feature area and reference the relevant source files.
+
+## 1. Authentication & Profile
+- **`lib/services/pocket_llm_service.dart`, `lib/services/auth_state.dart`**
+  - Replace local API key initialization and secure-storage token management with
+    backend-issued credentials. Remove the fallback demo key bundled with the app.
+  - Ensure all login, logout, and profile refresh flows call backend endpoints only;
+    eliminate shared-preference flags such as `authSkipped` once server-driven sessions
+    are enforced.
+- **`lib/pages/auth/auth_page.dart`, `lib/pages/auth/auth_flow_screen.dart`**
+  - Audit UI flows that bypass authentication ("Skip" path) and coordinate with backend
+    requirements before keeping or removing the option.
+
+## 2. Model Management
+- **`lib/component/models.dart`, `lib/services/model_service.dart`, `lib/services/model_state.dart`**
+  - Stop persisting models purely on device; move CRUD, health checks, and default model
+    selection to backend APIs.
+  - Align the local enums/metadata with backend contracts and consider generating models
+    from shared schemas.
+- **`lib/component/model_config_dialog.dart`, `lib/component/model_list_item.dart`, `lib/pages/model_settings_page.dart`**
+  - Remove direct HTTP calls to provider APIs. Instead, let the backend broker provider
+    imports and return sanitized configuration options.
+- **`lib/component/ollama_model.dart`, `lib/pages/library_page.dart`, `lib/component/model_parameter_dialog.dart`**
+  - Delete or fully rework the embedded Ollama catalog and Termux automation once server
+    orchestrates model downloads. Device-level shell execution should be retired.
+
+## 3. Chat & Conversation Storage
+- **`lib/services/chat_service.dart`, `lib/component/chat_interface.dart`**
+  - Route all chat completions through backend gateways; drop per-provider HTTP clients
+    and inline API keys.
+  - Replace Tavily direct calls (`lib/component/tavily_service.dart`) with backend search
+    proxy endpoints.
+- **`lib/services/chat_history_service.dart`, `lib/component/chat_history_manager.dart`, `lib/component/appbar/chat_history.dart`**
+  - Migrate conversation persistence from shared preferences to backend storage so chat
+    history syncs across devices.
+
+## 4. Search Integrations
+- **`lib/services/search_service.dart`, `lib/component/search_config_dialog.dart`,
+  `lib/pages/search_settings_page.dart`**
+  - Remove local credential storage and HTTP calls. Persist search provider settings on
+    the backend and expose a unified search API to the client.
+
+## 5. Device / Termux Utilities
+- **`lib/services/termux_service.dart`, `lib/pages/config_page.dart`, `lib/pages/library_page.dart`**
+  - Reassess whether on-device Termux automation remains in scope. If the backend manages
+    model deployments, delete these classes and replace with server-triggered workflows.
+
+## 6. Documentation & Content
+- **`lib/component/appbar/docs.dart`, `lib/pages/docs_page.dart`**
+  - Remove duplicated hardcoded markdown and fetch documentation links/content from the
+    backend or a CMS.
+
+## 7. General Cleanup
+- Ensure every module that currently reads/writes `SharedPreferences` is evaluated. Any
+  persisted state that should be portable (API keys, models, surveys, chat transcripts)
+  must be migrated to backend storage with secure access control.
+- After backend services cover these responsibilities, delete unused classes, constants,
+  and UI affordances that were designed around device-only execution.
+
+Completing these tasks will leave the Flutter codebase responsible for presentation and
+lightweight orchestration while the backend owns state, credentials, and integrations.

--- a/lib/component/appbar/about.dart
+++ b/lib/component/appbar/about.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Static About page describing PocketLLM mission and links.
+/// - Backend Migration: Keep but refresh copy once backend-driven feature list
+///   stabilizes.
 import 'package:flutter/material.dart';
 import 'package:url_launcher/url_launcher.dart';
 import 'dart:ui';

--- a/lib/component/appbar/chat_history.dart
+++ b/lib/component/appbar/chat_history.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Drawer-style chat history manager that reads/writes local
+///   conversations.
+/// - Backend Migration: Keep UI but rewire to backend chat history service when
+///   available.
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 

--- a/lib/component/appbar/docs.dart
+++ b/lib/component/appbar/docs.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: In-app documentation tabs for Termux and Ollama setup rendered
+///   directly in the Flutter client.
+/// - Backend Migration: Replace hardcoded markdown with backend-served content
+///   or deep links to official docs.
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/lib/component/chat_history_manager.dart
+++ b/lib/component/chat_history_manager.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Legacy helper that persists single-conversation history in local
+///   shared preferences.
+/// - Backend Migration: Remove when chat transcripts are synchronized via
+///   backend storage.
 import 'dart:convert';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'models.dart';

--- a/lib/component/chat_interface.dart
+++ b/lib/component/chat_interface.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Core chat UI handling message rendering, attachments, and direct
+///   calls to various model/search services.
+/// - Backend Migration: Substantially refactor; remove embedded API keys,
+///   switch to backend chat/search endpoints, and simplify local state.
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:clipboard/clipboard.dart';

--- a/lib/component/custom_app_bar.dart
+++ b/lib/component/custom_app_bar.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Custom app bar showing selected model and quick navigation
+///   actions.
+/// - Backend Migration: Keep UI but ensure model menu reflects backend-managed
+///   state.
 import 'dart:ui';
 import 'package:flutter/material.dart';
 import '../pages/config_page.dart';

--- a/lib/component/home_screen.dart
+++ b/lib/component/home_screen.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Main application shell combining app bar, sidebar, and chat body.
+/// - Backend Migration: Keep; ensure actions trigger backend-aware flows once
+///   chat/state become server-driven.
 import 'package:flutter/material.dart';
 import 'custom_app_bar.dart';
 import 'chat_interface.dart';

--- a/lib/component/model_config_dialog.dart
+++ b/lib/component/model_config_dialog.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Dialog for creating/editing model configurations with provider
+///   specific helpers.
+/// - Backend Migration: Keep UI but remove direct HTTP calls and rely on
+///   backend-administered model import flows.
 import 'package:flutter/material.dart';
 import '../services/model_service.dart';
 import '../component/models.dart';

--- a/lib/component/model_input_dialog.dart
+++ b/lib/component/model_input_dialog.dart
@@ -1,3 +1,6 @@
+/// File Overview:
+/// - Purpose: Reusable permission dialog for confirming sensitive actions.
+/// - Backend Migration: Keep; triggers may change but dialog remains UI-only.
 import 'package:flutter/material.dart';
 
 class PermissionDialog extends StatelessWidget {

--- a/lib/component/model_list_item.dart
+++ b/lib/component/model_list_item.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Visual representation of a model configuration with actions to
+///   edit, select, or delete.
+/// - Backend Migration: Keep UI but rely on backend-managed models for data.
 import 'package:flutter/material.dart';
 import '../component/models.dart';
 import 'model_config_dialog.dart';

--- a/lib/component/model_parameter_dialog.dart
+++ b/lib/component/model_parameter_dialog.dart
@@ -1,3 +1,6 @@
+/// File Overview:
+/// - Purpose: UI dialog for selecting Ollama model variants and features.
+/// - Backend Migration: Keep UI but feed it with backend-sourced metadata.
 import 'package:flutter/material.dart';
 import 'ollama_model.dart';
 

--- a/lib/component/model_selector.dart
+++ b/lib/component/model_selector.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Interactive UI widget that renders model selection controls with
+///   optional health indicators.
+/// - Backend Migration: Keep UI but ensure data is sourced from backend-driven
+///   model state rather than local caches.
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'models.dart';

--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Shared data models used across the frontend, including message
+///   history and provider metadata with some hardcoded defaults.
+/// - Backend Migration: Review all classes; many fields (e.g., provider lists,
+///   static enums) should align with backend contracts instead of local copies.
 import '../services/model_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/foundation.dart';

--- a/lib/component/ollama_model.dart
+++ b/lib/component/ollama_model.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Data model representing Ollama catalog entries with hardcoded
+///   metadata.
+/// - Backend Migration: Replace the static catalog with backend-provided model
+///   metadata to avoid shipping outdated lists.
 import 'package:flutter/material.dart';
 
 class OllamaModel {

--- a/lib/component/onboarding_screens/first_screen.dart
+++ b/lib/component/onboarding_screens/first_screen.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: First onboarding slide introducing the product.
+/// - Backend Migration: Keep but consider hosting animations locally to avoid
+///   runtime network dependency.
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 

--- a/lib/component/onboarding_screens/onboarding_screen.dart
+++ b/lib/component/onboarding_screens/onboarding_screen.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Hosts the onboarding pager and transitions to authentication.
+/// - Backend Migration: Keep but update completion flow once backend dictates
+///   whether onboarding is required.
 import 'package:flutter/material.dart';
 import 'package:smooth_page_indicator/smooth_page_indicator.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/component/onboarding_screens/second_screen.dart
+++ b/lib/component/onboarding_screens/second_screen.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Second onboarding slide focused on model customization messaging.
+/// - Backend Migration: Keep; revise copy once backend-managed model catalog is
+///   live.
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 

--- a/lib/component/onboarding_screens/third_screen.dart
+++ b/lib/component/onboarding_screens/third_screen.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Third onboarding slide that highlights web search integration.
+/// - Backend Migration: Keep; update messaging when backend delivers unified
+///   search proxy.
 import 'package:flutter/material.dart';
 import 'package:lottie/lottie.dart';
 

--- a/lib/component/search_config_dialog.dart
+++ b/lib/component/search_config_dialog.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Dialog for configuring search providers and storing credentials
+///   locally.
+/// - Backend Migration: Keep UI but route save/test actions through backend
+///   search proxy APIs to avoid exposing keys.
 import 'package:flutter/material.dart';
 import '../services/search_service.dart';
 

--- a/lib/component/sidebar.dart
+++ b/lib/component/sidebar.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Drawer navigation housing chat history shortcuts and links to
+///   other pages.
+/// - Backend Migration: Keep but update data sources (history, docs) to use
+///   backend services.
 import 'dart:math' as math;
 
 import 'package:flutter/material.dart';

--- a/lib/component/splash_screen.dart
+++ b/lib/component/splash_screen.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Animated splash experience shown during initial service
+///   initialization.
+/// - Backend Migration: Keep for UX polish; ensure animation duration matches
+///   backend initialization once remote boot becomes faster.
 import 'package:flutter/material.dart';
 import 'dart:math' as math;
 

--- a/lib/component/survey/survey_option_tile.dart
+++ b/lib/component/survey/survey_option_tile.dart
@@ -1,3 +1,6 @@
+/// File Overview:
+/// - Purpose: Stateless UI tile used in onboarding surveys to select options.
+/// - Backend Migration: Keep; purely visual component.
 import 'package:flutter/material.dart';
 
 class SurveyOptionTile extends StatelessWidget {

--- a/lib/component/survey/survey_progress_indicator.dart
+++ b/lib/component/survey/survey_progress_indicator.dart
@@ -1,3 +1,6 @@
+/// File Overview:
+/// - Purpose: Visual indicator for onboarding survey progress.
+/// - Backend Migration: Keep; no backend dependency.
 import 'package:flutter/material.dart';
 
 class SurveyProgressIndicator extends StatelessWidget {

--- a/lib/component/tavily_service.dart
+++ b/lib/component/tavily_service.dart
@@ -1,3 +1,6 @@
+/// File Overview:
+/// - Purpose: Direct Tavily search client called from the chat interface.
+/// - Backend Migration: Remove once backend exposes a secure search proxy.
 import 'dart:convert';
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,9 @@
+/// File Overview:
+/// - Purpose: Entry point that wires up lifecycle, theming, authentication, and
+///   bootstrapping so the Flutter shell can render the chat experience.
+/// - Backend Migration: Keep this file but plan to remove direct API key
+///   initialization and inline fallback flows once the backend exposes managed
+///   configuration endpoints.
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'component/splash_screen.dart';

--- a/lib/models/survey_model.dart
+++ b/lib/models/survey_model.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Data models representing onboarding survey questions, options,
+///   and responses.
+/// - Backend Migration: Keep but ensure schema mirrors backend survey payloads.
 import 'package:equatable/equatable.dart';
 
 class SurveyQuestion extends Equatable {

--- a/lib/models/user_profile.dart
+++ b/lib/models/user_profile.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Immutable representation of a user profile synchronized with the
+///   backend.
+/// - Backend Migration: Keep but confirm fields align with backend DTOs to
+///   prevent divergence.
 import 'package:equatable/equatable.dart';
 
 class UserProfile extends Equatable {

--- a/lib/pages/api_keys_page.dart
+++ b/lib/pages/api_keys_page.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Manage provider API keys and activation state directly from the
+///   client.
+/// - Backend Migration: Keep UI but ensure key storage/activation happens on
+///   the backend rather than device-side.
 import 'package:flutter/material.dart';
 import '../services/model_service.dart';
 import '../component/models.dart';

--- a/lib/pages/auth/auth_flow_screen.dart
+++ b/lib/pages/auth/auth_flow_screen.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Coordinates authentication flow, survey completion, and routing
+///   into the app.
+/// - Backend Migration: Keep but ensure skip/login logic reflects backend
+///   session rules rather than local shared preferences.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/pages/auth/auth_page.dart
+++ b/lib/pages/auth/auth_page.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Handles sign-in and sign-up UI, including survey handoff.
+/// - Backend Migration: Keep but ensure it relies solely on backend auth flows
+///   without local shortcuts or stored preferences for auth state.
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';

--- a/lib/pages/auth/user_survey_page.dart
+++ b/lib/pages/auth/user_survey_page.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Collects onboarding survey data locally before sending via
+///   `SurveyService`.
+/// - Backend Migration: Keep UI but ensure submission persists through backend
+///   APIs; consider reducing stored demographic questions if backend changes.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 

--- a/lib/pages/config_page.dart
+++ b/lib/pages/config_page.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Device configuration checklist that inspects Termux installation
+///   and hardware stats locally.
+/// - Backend Migration: Reevaluate necessity; backend onboarding may make this
+///   redundant or require sanitized telemetry reporting instead of direct checks.
 import 'package:flutter/material.dart';
 import 'dart:io';
 import 'dart:ui';

--- a/lib/pages/docs_page.dart
+++ b/lib/pages/docs_page.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Fullscreen documentation view duplicating the app bar docs tabs.
+/// - Backend Migration: Replace hardcoded markdown with backend-served
+///   documentation sources.
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:url_launcher/url_launcher.dart';

--- a/lib/pages/library_page.dart
+++ b/lib/pages/library_page.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Frontend library for browsing and installing Ollama models with
+///   direct device commands and hardcoded catalog entries.
+/// - Backend Migration: Replace with backend-managed marketplace data and
+///   server-triggered installs; much of this logic should move off-device.
 import 'package:flutter/material.dart';
 import '../component/models.dart';
 import 'dart:ui';

--- a/lib/pages/model_settings_page.dart
+++ b/lib/pages/model_settings_page.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Manage model configurations and providers entirely from the
+///   client UI.
+/// - Backend Migration: Keep UI but rely on backend-managed providers/models,
+///   removing any direct client-side persistence.
 import 'package:flutter/material.dart';
 import '../component/models.dart';
 import '../component/model_config_dialog.dart';

--- a/lib/pages/search_settings_page.dart
+++ b/lib/pages/search_settings_page.dart
@@ -1,4 +1,9 @@
- import 'package:flutter/material.dart';
+/// File Overview:
+/// - Purpose: Alternate search configuration screen persisting provider API
+///   keys locally.
+/// - Backend Migration: Consolidate with backend-managed search settings and
+///   remove local storage of secrets.
+import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:uuid/uuid.dart';
 import 'dart:convert';

--- a/lib/pages/settings/profile_settings.dart
+++ b/lib/pages/settings/profile_settings.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Profile management screen allowing users to update personal info
+///   and avatars directly.
+/// - Backend Migration: Keep but ensure all operations call backend endpoints
+///   (no local shared preference fallbacks).
 import 'dart:io';
 
 import 'package:flutter/material.dart';

--- a/lib/pages/settings_page.dart
+++ b/lib/pages/settings_page.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Settings hub that links to theming, profile, model, and API key
+///   configuration screens.
+/// - Backend Migration: Keep but audit sections that reference local-only
+///   features (e.g., direct model saves) as backend ownership grows.
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'dart:ui';

--- a/lib/services/api_config.dart
+++ b/lib/services/api_config.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Convenience wrapper that resolves the base API URL using
+///   `ApiEndpoints` helpers for legacy front-end HTTP calls.
+/// - Backend Migration: Deprecate alongside `PocketLLMService`; the backend
+///   should inform the client about routing without this indirection.
 import 'api_endpoints.dart';
 
 final String apiBaseUrl = ApiEndpoints.buildUri(

--- a/lib/services/api_endpoints.dart
+++ b/lib/services/api_endpoints.dart
@@ -1,3 +1,7 @@
+/// File Overview:
+/// - Purpose: Utility for normalizing backend URLs and building endpoint URIs.
+/// - Backend Migration: Keep until backend provides generated API client; then
+///   consolidate to avoid duplicated string handling.
 import 'package:flutter/foundation.dart';
 
 class ApiEndpoints {

--- a/lib/services/app_lifecycle_service.dart
+++ b/lib/services/app_lifecycle_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Coordinates service initialization order and tracks lifecycle
+///   state transitions for the Flutter shell.
+/// - Backend Migration: Keep but ensure initialization list reflects backend
+///   driven services instead of legacy client-only helpers.
 import 'dart:async';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/widgets.dart';

--- a/lib/services/auth_state.dart
+++ b/lib/services/auth_state.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Handles authentication tokens, profile state, and backend session
+///   interactions from the Flutter client.
+/// - Backend Migration: Keep but refactor to rely on backend-auth flows; remove
+///   any local token fallbacks as server support matures.
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/lib/services/backend_api_service.dart
+++ b/lib/services/backend_api_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Low-level HTTP client that supports base URL fallbacks and token
+///   injection for backend API access.
+/// - Backend Migration: Keep but audit once backend consolidates URLs and
+///   authentication; may be replaced by generated client.
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';

--- a/lib/services/chat_history_service.dart
+++ b/lib/services/chat_history_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Manages chat conversations locally using shared preferences and
+///   exposes notifiers for UI updates.
+/// - Backend Migration: Replace persistence with backend conversation APIs so
+///   history is synchronized across devices.
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/services/chat_service.dart
+++ b/lib/services/chat_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Routes chat requests from the UI directly to various model
+///   providers with provider-specific HTTP implementations.
+/// - Backend Migration: Deprecate once all chat generation flows are proxied
+///   through backend orchestration.
 import 'dart:convert';
 import 'dart:async';
 import 'package:flutter/material.dart';

--- a/lib/services/error_service.dart
+++ b/lib/services/error_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Centralized error logging with local persistence and recovery
+///   hints.
+/// - Backend Migration: Keep but forward logs to backend observability instead
+///   of storing solely in shared preferences.
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/services/model_service.dart
+++ b/lib/services/model_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Client-side orchestration layer for model CRUD operations that
+///   mixes backend calls with cached fallbacks.
+/// - Backend Migration: Simplify to a pure data access wrapper once backend
+///   persists models and selection state.
 import 'dart:convert';
 
 import 'package:flutter/foundation.dart';

--- a/lib/services/model_state.dart
+++ b/lib/services/model_state.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Observable state container that keeps track of available models,
+///   selection, and health checks for client-side decision making.
+/// - Backend Migration: Reduce scope once backend delivers curated model lists
+///   and health telemetry so the frontend only consumes summarized states.
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';

--- a/lib/services/network_service.dart
+++ b/lib/services/network_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Tracks connectivity status and queues outbound messages while
+///   offline.
+/// - Backend Migration: Keep but integrate with backend sync signals so queuing
+///   semantics align with server expectations.
 import 'dart:async';
 import 'dart:io';
 import 'package:flutter/foundation.dart';

--- a/lib/services/pocket_llm_service.dart
+++ b/lib/services/pocket_llm_service.dart
@@ -1,3 +1,10 @@
+/// File Overview:
+/// - Purpose: Legacy client-side service that stores API keys locally and
+///   performs direct HTTP calls to PocketLLM endpoints with hardcoded fallback
+///   models and responses.
+/// - Backend Migration: Mark for removal once backend-managed authentication,
+///   model discovery, and chat completion endpoints are wired through a single
+///   gateway.
 import 'dart:convert';
 
 import 'package:flutter/material.dart';

--- a/lib/services/remote_model_service.dart
+++ b/lib/services/remote_model_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Frontend wrapper around the backend `/providers` and `/models`
+///   endpoints that keeps UI state in sync with remote model configuration.
+/// - Backend Migration: Keep but slim down; this layer should become a thin
+///   data access client once backend covers all provider/model logic.
 import 'package:flutter/foundation.dart';
 import '../component/models.dart';
 import 'backend_api_service.dart';

--- a/lib/services/search_service.dart
+++ b/lib/services/search_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Stores third-party search provider settings locally and performs
+///   direct HTTP requests (e.g., Tavily) from the device.
+/// - Backend Migration: Replace with backend proxy endpoints so secrets and
+///   provider integrations are centralized server-side.
 import 'dart:convert';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;

--- a/lib/services/secure_storage_service.dart
+++ b/lib/services/secure_storage_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Client-side vault for encrypting API keys and provider metadata
+///   using Flutter secure storage.
+/// - Backend Migration: Replace with backend-managed credential storage to
+///   avoid persisting secrets on devices.
 import 'dart:convert';
 import 'dart:math';
 import 'dart:typed_data';

--- a/lib/services/survey_service.dart
+++ b/lib/services/survey_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Thin wrapper around `AuthState` used by the onboarding survey to
+///   populate a user profile.
+/// - Backend Migration: Keep as coordinator but ensure it calls real backend
+///   survey/profile endpoints instead of local state once available.
 import 'package:meta/meta.dart';
 
 import 'auth_state.dart';

--- a/lib/services/termux_service.dart
+++ b/lib/services/termux_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Experimental helper that attempts to launch and automate Termux
+///   on Android devices to execute shell commands from the UI.
+/// - Backend Migration: Likely obsolete; backend job runners should own command
+///   execution rather than relying on device-level automation.
 import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/material.dart';
 import 'dart:io';

--- a/lib/services/theme_service.dart
+++ b/lib/services/theme_service.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Centralized theme manager that persists color preferences and
+///   exposes Material `ThemeData` configurations to the app.
+/// - Backend Migration: Keep; consider allowing the backend to push branding
+///   metadata instead of forcing local defaults.
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:shared_preferences/shared_preferences.dart';

--- a/lib/theme/app_colors.dart
+++ b/lib/theme/app_colors.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Central palette definitions used to keep visual styling
+///   consistent across PocketLLM themes.
+/// - Backend Migration: Keep; colors remain frontend concerns although they
+///   may later respond to backend-provided branding options.
 import 'package:flutter/material.dart';
 
 /// Foundational color tokens used across PocketLLM.

--- a/lib/widgets/clear_text_field.dart
+++ b/lib/widgets/clear_text_field.dart
@@ -1,3 +1,8 @@
+/// File Overview:
+/// - Purpose: Reusable text field widget that exposes a built-in clear action
+///   to simplify form inputs across the UI.
+/// - Backend Migration: Keep; this is purely presentation logic and can remain
+///   unchanged when backend-driven data is introduced.
 import 'package:flutter/material.dart';
 
 class ClearTextField extends StatefulWidget {


### PR DESCRIPTION
## Summary
- add a frontend cleanup task list that enumerates hardcoded behaviours slated for backend ownership
- annotate every frontend source file with a brief description and backend migration guidance

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d6b44ef7f8832d867e4fb920ce072c