### PR TITLE
Revamp profile settings and onboarding flow

### DIFF
--- a/lib/component/survey/survey_option_tile.dart
+++ b/lib/component/survey/survey_option_tile.dart
@@ -6,6 +6,7 @@ import 'package:flutter/material.dart';
 class SurveyOptionTile extends StatelessWidget {
   final String label;
   final bool selected;
+  final bool isMultiSelect;
   final VoidCallback onTap;
 
   const SurveyOptionTile({
@@ -13,7 +14,53 @@ class SurveyOptionTile extends StatelessWidget {
     required this.label,
     required this.selected,
     required this.onTap,
+    this.isMultiSelect = false,
   });
+
+  Widget _buildIndicator(ThemeData theme) {
+    if (isMultiSelect) {
+      final borderColor = selected ? theme.colorScheme.primary : Colors.grey.shade400;
+      return AnimatedContainer(
+        duration: const Duration(milliseconds: 200),
+        width: 22,
+        height: 22,
+        decoration: BoxDecoration(
+          borderRadius: BorderRadius.circular(6),
+          border: Border.all(color: borderColor, width: 2),
+          color: selected ? theme.colorScheme.primary : Colors.transparent,
+        ),
+        child: AnimatedOpacity(
+          opacity: selected ? 1 : 0,
+          duration: const Duration(milliseconds: 200),
+          child: const Icon(Icons.check, color: Colors.white, size: 14),
+        ),
+      );
+    }
+
+    return AnimatedContainer(
+      duration: const Duration(milliseconds: 200),
+      width: 20,
+      height: 20,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(
+          color: selected ? theme.colorScheme.primary : Colors.grey.shade400,
+          width: 2,
+        ),
+      ),
+      child: AnimatedScale(
+        duration: const Duration(milliseconds: 200),
+        scale: selected ? 1 : 0,
+        child: Container(
+          margin: const EdgeInsets.all(3),
+          decoration: BoxDecoration(
+            color: theme.colorScheme.primary,
+            shape: BoxShape.circle,
+          ),
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -43,29 +90,7 @@ class SurveyOptionTile extends StatelessWidget {
                 ),
               ),
             ),
-            AnimatedContainer(
-              duration: const Duration(milliseconds: 200),
-              width: 20,
-              height: 20,
-              decoration: BoxDecoration(
-                shape: BoxShape.circle,
-                border: Border.all(
-                  color: isSelected ? theme.colorScheme.primary : Colors.grey.shade400,
-                  width: 2,
-                ),
-              ),
-              child: AnimatedScale(
-                duration: const Duration(milliseconds: 200),
-                scale: isSelected ? 1 : 0,
-                child: Container(
-                  margin: const EdgeInsets.all(3),
-                  decoration: BoxDecoration(
-                    color: theme.colorScheme.primary,
-                    shape: BoxShape.circle,
-                  ),
-                ),
-              ),
-            ),
+            _buildIndicator(theme),
           ],
         ),
       ),

--- a/lib/services/survey_service.dart
+++ b/lib/services/survey_service.dart
@@ -12,6 +12,7 @@ class SurveyPayload {
   final String fullName;
   final String username;
   final String? bio;
+  final DateTime? dateOfBirth;
   final String? profession;
   final String? heardFrom;
   final Map<String, dynamic>? onboarding;
@@ -20,6 +21,7 @@ class SurveyPayload {
     required this.fullName,
     required this.username,
     this.bio,
+    this.dateOfBirth,
     this.profession,
     this.heardFrom,
     this.onboarding,
@@ -36,7 +38,7 @@ class SurveyService {
       fullName: payload.fullName,
       username: payload.username,
       bio: payload.bio,
-      dateOfBirth: null,
+      dateOfBirth: payload.dateOfBirth,
       profession: payload.profession,
       heardFrom: payload.heardFrom,
       avatarUrl: null,


### PR DESCRIPTION
## Summary
- redesign the profile settings page with a fresh header, sectioned action cards, and remove redundant notification/theme toggles
- expand the onboarding survey to gather date of birth, profession details, and richer preference questions while supporting multi-select answers
- persist profile data locally in auth state so sessions survive restarts even when services are unavailable

## Testing
- `flutter analyze` *(fails: flutter command not available in container)*
- `flutter test` *(fails: flutter command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d78ae932c0832db46b382185af807d