### PR TITLE
Handle missing provider credentials when listing models

### DIFF
--- a/pocketllm-backend/app/api/v1/endpoints/models.py
+++ b/pocketllm-backend/app/api/v1/endpoints/models.py
@@ -33,7 +33,7 @@ async def list_models(
     name: str | None = Query(default=None, description="Case-insensitive substring filter applied to model names"),
     model_id: str | None = Query(default=None, description="Case-insensitive substring filter applied to model identifiers"),
     query: str | None = Query(default=None, description="Free text search across model id, name, and description"),
-) -> list[ProviderModel]:
+) -> ProviderModelsResponse:
     service = ProvidersService(settings=settings, database=database)
     return await service.get_provider_models(
         user.sub,

--- a/pocketllm-backend/app/services/provider_configs.py
+++ b/pocketllm-backend/app/services/provider_configs.py
@@ -166,7 +166,8 @@ class ProvidersService:
             if self._record_is_usable(record)
         ]
 
-        configured_providers = sorted({record.provider for record in active_records})
+        configured_providers_set = {record.provider.lower() for record in active_records}
+        configured_providers = sorted(configured_providers_set)
         supported_providers = sorted(_SUPPORTED_PROVIDERS)
 
         if provider is None:
@@ -198,7 +199,7 @@ class ProvidersService:
             missing = [
                 provider_name
                 for provider_name in supported_providers
-                if provider_name not in configured_providers
+                if provider_name not in configured_providers_set
             ]
             return ProviderModelsResponse(
                 models=filtered,
@@ -219,7 +220,7 @@ class ProvidersService:
                 f"Provider '{provider}' is not configured or is inactive for this workspace."
             )
             missing = sorted({provider_key} | set(
-                p for p in supported_providers if p not in configured_providers
+                p for p in supported_providers if p not in configured_providers_set
             ))
             return ProviderModelsResponse(
                 models=[],
@@ -251,7 +252,7 @@ class ProvidersService:
             missing_providers=[
                 provider_name
                 for provider_name in supported_providers
-                if provider_name not in configured_providers
+                if provider_name not in configured_providers_set
             ],
         )
 

--- a/pocketllm-backend/app/services/provider_configs.py
+++ b/pocketllm-backend/app/services/provider_configs.py
@@ -158,13 +158,102 @@ class ProvidersService:
         name: str | None = None,
         model_id: str | None = None,
         query: str | None = None,
-    ) -> list[ProviderModel]:
+    ) -> ProviderModelsResponse:
         records = await self._fetch_provider_records(user_id)
+        active_records = [
+            record
+            for record in records
+            if self._record_is_usable(record)
+        ]
+
+        configured_providers = sorted({record.provider for record in active_records})
+        supported_providers = sorted(_SUPPORTED_PROVIDERS)
+
         if provider is None:
-            models = await self._catalogue.list_all_models(records)
-        else:
-            models = await self._catalogue.list_models_for_provider(provider, records)
-        return self._filter_models(models, name=name, model_id=model_id, query=query)
+            if not active_records:
+                return ProviderModelsResponse(
+                    models=[],
+                    message=(
+                        "No providers are configured for this workspace. "
+                        "Add a provider to browse available models."
+                    ),
+                    configured_providers=[],
+                    missing_providers=supported_providers,
+                )
+
+            models = await self._catalogue.list_all_models(active_records)
+            filtered = self._filter_models(
+                models,
+                name=name,
+                model_id=model_id,
+                query=query,
+            )
+            message = None
+            if not filtered:
+                if any([name, model_id, query]):
+                    message = "No models matched the provided filters."
+                else:
+                    message = "No models are currently available from the configured providers."
+
+            missing = [
+                provider_name
+                for provider_name in supported_providers
+                if provider_name not in configured_providers
+            ]
+            return ProviderModelsResponse(
+                models=filtered,
+                message=message,
+                configured_providers=configured_providers,
+                missing_providers=missing,
+            )
+
+        provider_key = provider.lower()
+        provider_records = [
+            record
+            for record in active_records
+            if record.provider.lower() == provider_key
+        ]
+
+        if not provider_records:
+            message = (
+                f"Provider '{provider}' is not configured or is inactive for this workspace."
+            )
+            missing = sorted({provider_key} | set(
+                p for p in supported_providers if p not in configured_providers
+            ))
+            return ProviderModelsResponse(
+                models=[],
+                message=message,
+                configured_providers=configured_providers,
+                missing_providers=missing,
+            )
+
+        models = await self._catalogue.list_models_for_provider(provider_key, provider_records)
+        filtered = self._filter_models(
+            models,
+            name=name,
+            model_id=model_id,
+            query=query,
+        )
+        message = None
+        if not filtered:
+            if any([name, model_id, query]):
+                message = "No models matched the provided filters."
+            else:
+                message = (
+                    f"No models are currently available for provider '{provider}'."
+                )
+
+        return ProviderModelsResponse(
+            models=filtered,
+            message=message,
+            configured_providers=configured_providers,
+            missing_providers=[
+                provider_name
+                for provider_name in supported_providers
+                if provider_name not in configured_providers
+            ],
+        )
 
     def _filter_models(
         self,
@@ -197,6 +286,16 @@ class ProvidersService:
             return True
 
         return [model for model in models if _matches(model)]
+
+    @staticmethod
+    def _record_is_usable(record: ProviderRecord) -> bool:
+        if not record.is_active:
+            return False
+        return bool(
+            (record.api_key and record.api_key.strip())
+            or record.api_key_encrypted
+            or record.api_key_hash
+        )
 
     async def _fetch_provider_records(self, user_id: UUID) -> list[ProviderRecord]:
         records = await self._database.select(

--- a/pocketllm-backend/tests/test_provider_catalogue.py
+++ b/pocketllm-backend/tests/test_provider_catalogue.py
@@ -9,6 +9,7 @@ import pytest
 
 httpx = pytest.importorskip("httpx")
 
+from app.core.config import Settings
 from app.schemas.providers import ProviderConfiguration, ProviderModel
 from app.services.provider_configs import ProvidersService
 from app.services.providers import (
@@ -683,17 +684,9 @@ async def test_providers_service_filters_models_by_attributes():
 
     guard_match = await service.get_provider_models(user_id, model_id="guard")
     assert [model.id for model in guard_match.models] == ["llama-guard"]
-    service = ProvidersService(make_settings(), database=FakeDatabase(), catalogue=FakeCatalogue(models))
-    user_id = uuid4()
 
-    moderation = await service.get_provider_models(user_id, query="moderation")
-    assert [model.id for model in moderation] == ["llama-guard"]
-
-    gpt_match = await service.get_provider_models(user_id, name="gpt-4")
-    assert [model.id for model in gpt_match] == ["gpt-4o"]
-
-    guard_match = await service.get_provider_models(user_id, model_id="guard")
-    assert [model.id for model in guard_match] == ["llama-guard"]
+    all_models = await service.get_provider_models(user_id)
+    assert {model.id for model in all_models.models} == {"gpt-4o", "llama-guard"}
 
 
 @pytest.mark.asyncio
@@ -718,6 +711,7 @@ async def test_providers_service_respects_provider_parameter():
 
     assert [model.provider for model in groq_models.models] == ["groq"]
     assert catalogue.calls and catalogue.calls[0][0] == "groq"
+
 
 
 @pytest.mark.asyncio
@@ -756,10 +750,22 @@ async def test_providers_service_requires_provider_configuration_for_specific_pr
     assert response.models == []
     assert response.message and "not configured" in response.message
     assert "groq" in response.missing_providers
+    models = [
+        ProviderModel(provider="openai", id="gpt-4o", name="GPT-4 Omni"),
+        ProviderModel(provider="groq", id="llama-guard", name="LLaMA Guard"),
+    ]
+    catalogue = FakeCatalogue(models)
     service = ProvidersService(make_settings(), database=FakeDatabase(), catalogue=catalogue)
     user_id = uuid4()
 
+    provider_records = [make_provider_record(provider="groq", user_id=user_id, api_key="groq-key")]
+
+    async def stub_fetch_groq(_: UUID) -> list[ProviderRecord]:
+        return provider_records
+
+    service._fetch_provider_records = stub_fetch_groq  # type: ignore[assignment]
+
     groq_models = await service.get_provider_models(user_id, provider="groq")
 
-    assert [model.provider for model in groq_models] == ["groq"]
+    assert [model.provider for model in groq_models.models] == ["groq"]
     assert catalogue.calls and catalogue.calls[0][0] == "groq"


### PR DESCRIPTION
## Summary
- return a ProviderModelsResponse envelope from the /v1/models endpoint instead of a bare list
- teach ProvidersService.get_provider_models to short-circuit when no usable provider credentials exist and add clearer messaging
- update provider catalogue tests for the new response structure

## Testing
- pytest tests/test_provider_catalogue.py *(fails: async plugin missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dba6d4fa1c832d97afd5c42e2d764c