### PR TITLE
Handle provider activation payloads posted as raw strings

### DIFF
--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -59,6 +59,29 @@ The hosted API is available at `https://pocket-llm-api.vercel.app`. OpenAPI docu
 pytest
 ```
 
+### Activating a provider
+
+Send JSON to `/v1/providers/activate` using the `application/json` content type. Raw JSON strings are also accepted, but must
+represent a valid JSON object. For example, to activate Groq with a custom timeout configuration:
+
+```bash
+curl \
+  -X POST http://127.0.0.1:8000/v1/providers/activate \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "provider": "groq",
+    "api_key": "gsk_your_api_key_here",
+    "base_url": "https://api.groq.com/openai/v1",
+    "metadata": {
+      "timeout": 30,
+      "max_retries": 2
+    }
+  }'
+```
+
+If you construct the request body dynamically (for example, in Postman), ensure the body is sent as JSON rather than plain text.
+
 ## Project Structure
 
 ```text


### PR DESCRIPTION
## Summary
- allow the provider activation schema to coerce raw JSON strings and metadata strings into objects before validation
- document the expected activation payload and headers in the backend README so Postman/curl requests succeed

## Testing
- pytest *(fails: missing Supabase credentials in the test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e36806c488832da05bc4c5ada55f7b