### PR TITLE
Add HTTP fallback for Groq API key validation

### DIFF
--- a/pocketllm-backend/tests/test_api_key_validation.py
+++ b/pocketllm-backend/tests/test_api_key_validation.py
@@ -1,0 +1,81 @@
+"""Tests for :mod:`app.services.api_keys`."""
+
+from __future__ import annotations
+
+import asyncio
+from contextlib import asynccontextmanager
+from typing import Any
+
+import httpx
+import pytest
+
+from app.core.config import Settings
+from app.services.api_keys import APIKeyValidationService
+
+
+def test_validate_groq_falls_back_to_http_when_sdk_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure Groq validation succeeds via HTTP when the SDK is unavailable."""
+
+    real_async_client = httpx.AsyncClient
+    captured_requests: list[httpx.Request] = []
+    captured_timeouts: list[Any] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_requests.append(request)
+        return httpx.Response(200, json={"data": []})
+
+    transport = httpx.MockTransport(handler)
+
+    @asynccontextmanager
+    async def client_factory(*args: Any, **kwargs: Any):
+        kwargs.setdefault("transport", transport)
+        captured_timeouts.append(kwargs.get("timeout"))
+        async with real_async_client(*args, **kwargs) as client:
+            yield client
+
+    monkeypatch.setattr("app.services.api_keys.AsyncGroq", None, raising=False)
+    monkeypatch.setattr("app.services.api_keys.httpx.AsyncClient", client_factory, raising=False)
+
+    service = APIKeyValidationService(Settings())
+
+    asyncio.run(
+        service.validate(
+            "groq",
+            "test-key",
+            base_url="https://api.groq.com/openai/v1/",
+            metadata={"timeout": "5"},
+        )
+    )
+
+    assert captured_requests, "Expected an HTTP request to be issued"
+    request = captured_requests[0]
+    assert request.headers["Authorization"] == "Bearer test-key"
+    assert request.url.path.endswith("/models")
+    assert captured_timeouts and captured_timeouts[0] == 5.0
+
+
+def test_validate_groq_http_fallback_raises_for_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    """HTTP fallback should surface non-success status codes as validation errors."""
+
+    real_async_client = httpx.AsyncClient
+
+    def handler(_: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, text="Forbidden")
+
+    transport = httpx.MockTransport(handler)
+
+    @asynccontextmanager
+    async def client_factory(*args: Any, **kwargs: Any):
+        kwargs.setdefault("transport", transport)
+        async with real_async_client(*args, **kwargs) as client:
+            yield client
+
+    monkeypatch.setattr("app.services.api_keys.AsyncGroq", None, raising=False)
+    monkeypatch.setattr("app.services.api_keys.httpx.AsyncClient", client_factory, raising=False)
+
+    service = APIKeyValidationService(Settings())
+
+    with pytest.raises(ValueError) as excinfo:
+        asyncio.run(service.validate("groq", "invalid", metadata={}))
+
+    assert "403" in str(excinfo.value)


### PR DESCRIPTION
## Summary
- add an HTTP-based fallback when the Groq SDK is unavailable during API key validation
- normalise metadata values passed to the Groq SDK and log the fallback reason
- cover Groq validation fallback scenarios with new unit tests

## Testing
- pytest tests/test_api_key_validation.py

------
https://chatgpt.com/codex/tasks/task_e_68e37244cdcc832da138a8f5b058b644