### PR TITLE
Support deriving Fernet key from passphrase

### DIFF
--- a/pocketllm-backend/.env.example
+++ b/pocketllm-backend/.env.example
@@ -11,6 +11,7 @@ SUPABASE_ANON_KEY=your_supabase_anon_key
 SUPABASE_SERVICE_ROLE_KEY=your_supabase_service_role_key
 
 # Encryption
+# Accepts either a Fernet token or a passphrase (a Fernet key will be derived automatically).
 ENCRYPTION_KEY=a_strong_32_byte_secret_key_for_encrypting_api_keys
 
 BACKEND_BASE_URL=https://pocket-llm-lemon.vercel.app/

--- a/pocketllm-backend/POSTMAN_API_GUIDE.md
+++ b/pocketllm-backend/POSTMAN_API_GUIDE.md
@@ -24,7 +24,7 @@ Follow these steps to prepare the NestJS backend before exercising the API colle
    ```bash
    cp .env.example .env
    ```
-   Update `.env` with your Supabase project URL and service role key (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) and set an `ENCRYPTION_KEY` for securing provider API keys.
+   Update `.env` with your Supabase project URL and service role key (`SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`) and set an `ENCRYPTION_KEY` for securing provider API keys. The key can be either a Fernet token (run `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`) or any strong passphrase—the backend will safely derive a Fernet key from the passphrase for you.
 3. **Run the development server**
    ```bash
    npm run start:dev

--- a/pocketllm-backend/tests/test_crypto_utils.py
+++ b/pocketllm-backend/tests/test_crypto_utils.py
@@ -1,0 +1,33 @@
+"""Tests for encryption utilities handling Fernet keys."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from cryptography.fernet import Fernet
+
+from app.utils.crypto import decrypt_secret, encrypt_secret
+
+
+@pytest.mark.parametrize(
+    "encryption_key",
+    [
+        Fernet.generate_key().decode("utf-8"),
+        "plain-text-secret",
+    ],
+)
+def test_encrypt_decrypt_roundtrip(encryption_key: str) -> None:
+    settings = SimpleNamespace(encryption_key=encryption_key)
+    secret = "super-secret-value"
+
+    token = encrypt_secret(secret, settings)
+
+    assert decrypt_secret(token, settings) == secret
+
+
+def test_missing_encryption_key_raises_runtime_error() -> None:
+    settings = SimpleNamespace(encryption_key="")
+
+    with pytest.raises(RuntimeError):
+        encrypt_secret("value", settings)


### PR DESCRIPTION
## Summary
- derive a Fernet token from passphrase-style ENCRYPTION_KEY values so provider activation no longer fails
- document the expanded ENCRYPTION_KEY behaviour in the setup guides and sample environment file
- add unit coverage for encrypting and decrypting secrets with both Fernet tokens and derived passphrases

## Testing
- pip install -r pocketllm-backend/requirements.txt
- pytest tests/test_crypto_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e37b3a07c8832daf9c2c341418ac4d