### PR TITLE
Handle binascii errors when loading Fernet keys

### DIFF
--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -34,10 +34,18 @@ SUPABASE_SERVICE_ROLE_KEY=<service-role-key>
 SUPABASE_ANON_KEY=<anon-key>
 SUPABASE_DB_URL=postgresql+asyncpg://<user>:<password>@<host>:5432/postgres
 SUPABASE_JWT_SECRET=<jwt-secret>
+ENCRYPTION_KEY=<fernet-key-or-32-char-secret>
 LOG_LEVEL=INFO
 ```
 
 Refer to [`API_DOCUMENTATION.md`](API_DOCUMENTATION.md) for the full list of optional settings.
+
+You can generate a compliant encryption key in two ways:
+
+- Use a Fernet key (recommended): `python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"`
+- Provide any 32-character string (for example, `export ENCRYPTION_KEY=$(openssl rand -hex 16 | cut -c1-32)`).
+
+If a raw 32-character string is supplied, the backend will automatically derive a Fernet-compatible key internally.
 
 ### 3. Initialise the database schema
 

--- a/pocketllm-backend/app/services/api_keys.py
+++ b/pocketllm-backend/app/services/api_keys.py
@@ -21,13 +21,12 @@ except Exception:  # pragma: no cover - defensive fallback when SDK missing
 _GROQ_IMPORT_ERROR: Exception | None = None
 
 try:  # pragma: no cover
-    from groq import AsyncGroq
-    from groq.errors import GroqError
+    from groq import APIError as GroqAPIError, AsyncGroq
 except Exception as exc:  # pragma: no cover
     AsyncGroq = None  # type: ignore[assignment]
     _GROQ_IMPORT_ERROR = exc
 
-    class GroqError(Exception):
+    class GroqAPIError(Exception):
         """Fallback Groq error."""
 
 
@@ -108,7 +107,7 @@ class APIKeyValidationService:
         client = AsyncGroq(**kwargs)
         try:
             await client.models.list()
-        except GroqError as exc:  # pragma: no cover
+        except GroqAPIError as exc:  # pragma: no cover
             raise ValueError(f"Groq API key validation failed: {exc}") from exc
         finally:
             await _close_client(client)

--- a/pocketllm-backend/app/services/providers/groq.py
+++ b/pocketllm-backend/app/services/providers/groq.py
@@ -16,12 +16,11 @@ from app.schemas.providers import ProviderModel
 from .base import ProviderClient
 
 try:  # pragma: no cover - exercised in production environments
-    from groq import AsyncGroq
-    from groq.errors import GroqError
+    from groq import APIError as GroqAPIError, AsyncGroq
 except Exception:  # pragma: no cover - defensive fallback for test environments
     AsyncGroq = None  # type: ignore[assignment]
 
-    class GroqError(Exception):
+    class GroqAPIError(Exception):
         """Fallback error type when the Groq SDK is unavailable."""
 
 
@@ -135,7 +134,7 @@ class GroqProviderClient(ProviderClient):
         try:
             async with _client_context(self._client_factory, **client_kwargs) as client:
                 payload = await client.models.list()
-        except GroqError as exc:  # pragma: no cover - depends on SDK error types
+        except GroqAPIError as exc:  # pragma: no cover - depends on SDK error types
             self._logger.error("Groq SDK request failed: %s", exc)
             return []
         except Exception:  # pragma: no cover - defensive catch-all
@@ -159,7 +158,7 @@ class GroqProviderClient(ProviderClient):
         try:
             async with _client_context(self._client_factory, **client_kwargs) as client:
                 payload = await client.models.list()
-        except GroqError as exc:  # pragma: no cover - depends on SDK error types
+        except GroqAPIError as exc:  # pragma: no cover - depends on SDK error types
             self._logger.error("Groq SDK request failed: %s", exc)
             return []
         except Exception:  # pragma: no cover - defensive catch-all
@@ -314,7 +313,7 @@ class GroqSDKService:
         async with self._client() as client:
             try:
                 return await client.chat.completions.create(model=model, messages=list(messages), **kwargs)
-            except GroqError as exc:  # pragma: no cover - depends on SDK runtime
+            except GroqAPIError as exc:  # pragma: no cover - depends on SDK runtime
                 self._logger.error("Groq chat completion failed: %s", exc)
                 raise
 
@@ -335,7 +334,7 @@ class GroqSDKService:
                         messages=list(messages),
                         **stream_kwargs,
                     )
-                except GroqError as exc:  # pragma: no cover - depends on SDK runtime
+                except GroqAPIError as exc:  # pragma: no cover - depends on SDK runtime
                     self._logger.error("Groq chat completion stream failed: %s", exc)
                     raise
                 async for chunk in stream:
@@ -349,7 +348,7 @@ class GroqSDKService:
         async with self._client() as client:
             try:
                 return await client.responses.create(**kwargs)
-            except GroqError as exc:  # pragma: no cover
+            except GroqAPIError as exc:  # pragma: no cover
                 self._logger.error("Groq response request failed: %s", exc)
                 raise
 
@@ -358,7 +357,7 @@ class GroqSDKService:
         async with self._client() as client:
             try:
                 return await client.audio.transcriptions.create(file=file, model=model, **kwargs)
-            except GroqError as exc:  # pragma: no cover
+            except GroqAPIError as exc:  # pragma: no cover
                 self._logger.error("Groq transcription failed: %s", exc)
                 raise
 
@@ -367,7 +366,7 @@ class GroqSDKService:
         async with self._client() as client:
             try:
                 return await client.audio.translations.create(file=file, model=model, **kwargs)
-            except GroqError as exc:  # pragma: no cover
+            except GroqAPIError as exc:  # pragma: no cover
                 self._logger.error("Groq translation failed: %s", exc)
                 raise
 
@@ -378,7 +377,7 @@ class GroqSDKService:
         async with self._client() as client:
             try:
                 return await client.audio.speech.create(**payload)
-            except GroqError as exc:  # pragma: no cover
+            except GroqAPIError as exc:  # pragma: no cover
                 self._logger.error("Groq speech synthesis failed: %s", exc)
                 raise
 

--- a/pocketllm-backend/app/utils/crypto.py
+++ b/pocketllm-backend/app/utils/crypto.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import binascii
 import logging
+from base64 import urlsafe_b64encode
 from typing import TYPE_CHECKING
 
 from cryptography.fernet import Fernet, InvalidToken
@@ -21,11 +23,23 @@ def _load_fernet(settings: "Settings") -> Fernet:
         raise RuntimeError(
             "Application encryption key is not configured. Set ENCRYPTION_KEY to a valid Fernet key."
         )
+    token = key.encode("utf-8")
     try:
-        token = key.encode("utf-8")
         return Fernet(token)
+    except (ValueError, TypeError, binascii.Error) as exc:
+        if len(token) == 32:
+            derived_key = urlsafe_b64encode(token)
+            logger.warning(
+                "Provided ENCRYPTION_KEY was not base64 encoded; derived Fernet key from raw 32-byte string."
+            )
+            return Fernet(derived_key)
+        raise RuntimeError(
+            "Invalid encryption key format. Ensure ENCRYPTION_KEY is a base64 encoded Fernet key or a 32-character string."
+        ) from exc
     except Exception as exc:  # pragma: no cover - defensive guard for invalid keys
-        raise RuntimeError("Invalid encryption key format. Ensure ENCRYPTION_KEY is a base64 encoded Fernet key.") from exc
+        raise RuntimeError(
+            "Invalid encryption key format. Ensure ENCRYPTION_KEY is a base64 encoded Fernet key or a 32-character string."
+        ) from exc
 
 
 def encrypt_secret(secret: str, settings: "Settings") -> str:

--- a/pocketllm-backend/tests/test_crypto.py
+++ b/pocketllm-backend/tests/test_crypto.py
@@ -1,0 +1,41 @@
+"""Tests for crypto utility helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from cryptography.fernet import Fernet
+
+from app.utils.crypto import decrypt_secret, encrypt_secret
+
+
+class _Settings:
+    def __init__(self, encryption_key: str) -> None:
+        self.encryption_key = encryption_key
+
+
+@pytest.mark.parametrize("secret", ["hello", "123", "🚀"])
+def test_encrypt_decrypt_roundtrip_with_base64_key(secret: str) -> None:
+    key = Fernet.generate_key().decode("utf-8")
+    settings = _Settings(encryption_key=key)
+
+    token = encrypt_secret(secret, settings)
+
+    assert decrypt_secret(token, settings) == secret
+
+
+@pytest.mark.parametrize("secret", ["token", "another secret"])
+def test_encrypt_decrypt_with_raw_32_char_key(secret: str) -> None:
+    raw_key = "a" * 32
+    settings = _Settings(encryption_key=raw_key)
+
+    token = encrypt_secret(secret, settings)
+
+    assert decrypt_secret(token, settings) == secret
+
+
+def test_encrypt_with_invalid_key_raises() -> None:
+    settings = _Settings(encryption_key="short")
+
+    with pytest.raises(RuntimeError):
+        encrypt_secret("secret", settings)

--- a/pocketllm-backend/tests/test_database_supabase_rest.py
+++ b/pocketllm-backend/tests/test_database_supabase_rest.py
@@ -1,9 +1,72 @@
+import logging
+import os
+import sys
+import types
+
+if "supabase" not in sys.modules:
+    supabase_stub = types.ModuleType("supabase")
+
+    class _StubQuery:
+        def select(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return self
+
+        def limit(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return self
+
+        def execute(self):  # type: ignore[no-untyped-def]
+            return types.SimpleNamespace(data=[])
+
+    class _StubClient:
+        def table(self, *_args, **_kwargs):  # type: ignore[no-untyped-def]
+            return _StubQuery()
+
+    def _create_client_stub(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        return _StubClient()
+
+    supabase_stub.Client = _StubClient
+    supabase_stub.create_client = _create_client_stub
+    sys.modules["supabase"] = supabase_stub
+
+os.environ.setdefault("SUPABASE_URL", "https://example.supabase.co")
+os.environ.setdefault("SUPABASE_SERVICE_ROLE_KEY", "service-role-key")
+
 from app.database.connection import SupabaseDatabase
 
 
 def _dummy_supabase() -> SupabaseDatabase:
     instance = object.__new__(SupabaseDatabase)
     return instance  # type: ignore[return-value]
+
+
+class _RecordingClient:
+    def __init__(self, *, fail_on_conflict: bool = False) -> None:
+        self.fail_on_conflict = fail_on_conflict
+        self.table_calls: list[str] = []
+        self.upsert_calls: list[dict[str, object]] = []
+        self.kwarg_calls: list[dict[str, object]] = []
+        self._payload: object | None = None
+
+    def table(self, name: str) -> "_RecordingClient":
+        self.table_calls.append(name)
+        return self
+
+    def upsert(self, payload, **kwargs):  # type: ignore[no-untyped-def]
+        if self.fail_on_conflict and kwargs:
+            raise TypeError("upsert() got an unexpected keyword argument 'on_conflict'")
+        self.upsert_calls.append(payload)
+        self.kwarg_calls.append(kwargs)
+        self._payload = payload
+        return self
+
+    def execute(self):  # type: ignore[no-untyped-def]
+        payload = self._payload
+        if isinstance(payload, list):
+            data = payload
+        elif payload is None:
+            data = []
+        else:
+            data = [payload]
+        return types.SimpleNamespace(data=data)
 
 
 def test_normalise_order_with_tuple() -> None:
@@ -25,3 +88,44 @@ def test_normalise_order_with_dict() -> None:
         {"column": "created_at", "ascending": False},
     )
     assert result == [("created_at", True)]
+
+
+def test_upsert_passes_on_conflict_keyword(caplog) -> None:  # type: ignore[no-untyped-def]
+    supabase = _dummy_supabase()
+    client = _RecordingClient()
+    supabase._client = client  # type: ignore[attr-defined]
+    supabase._initialised = True  # type: ignore[attr-defined]
+
+    caplog.set_level(logging.INFO)
+    result = SupabaseDatabase.upsert(
+        supabase,
+        "providers",
+        {"id": "123", "provider": "openai"},
+        on_conflict="user_id,provider",
+    )
+
+    assert client.table_calls == ["providers"]
+    assert client.kwarg_calls[0]["on_conflict"] == "user_id,provider"
+    assert result == [{"id": "123", "provider": "openai"}]
+
+
+def test_upsert_falls_back_when_on_conflict_unavailable(caplog) -> None:  # type: ignore[no-untyped-def]
+    supabase = _dummy_supabase()
+    client = _RecordingClient(fail_on_conflict=True)
+    supabase._client = client  # type: ignore[attr-defined]
+    supabase._initialised = True  # type: ignore[attr-defined]
+
+    caplog.set_level(logging.WARNING)
+    result = SupabaseDatabase.upsert(
+        supabase,
+        "providers",
+        {"id": "456", "provider": "anthropic"},
+        on_conflict="user_id,provider",
+    )
+
+    # The first attempt raises a TypeError which triggers a second call with
+    # no kwargs. We only care that the fallback call succeeds without kwargs
+    # and that a warning is logged for operators.
+    assert client.kwarg_calls[-1] == {}
+    assert result == [{"id": "456", "provider": "anthropic"}]
+    assert "does not support on_conflict" in caplog.text


### PR DESCRIPTION
## Summary
- import the binascii module and catch binascii.Error when loading Fernet keys
- retain the raw 32-character fallback while surfacing a consistent runtime error for unsupported formats

## Testing
- pytest pocketllm-backend/tests/test_crypto.py

------
https://chatgpt.com/codex/tasks/task_e_68e37b3a07c8832daf9c2c341418ac4d