### PR TITLE
Fix Groq base URL handling

### DIFF
--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -80,13 +80,17 @@ curl \
   -d '{
     "provider": "groq",
     "api_key": "gsk_your_api_key_here",
-    "base_url": "https://api.groq.com/openai/v1",
+    "base_url": "https://api.groq.com",
     "metadata": {
       "timeout": 30,
       "max_retries": 2
     }
   }'
 ```
+
+Providing the bare domain is sufficient—the backend automatically adds Groq's
+`/openai/v1` compatibility prefix for HTTP calls while stripping it for the
+official SDK.
 
 If you construct the request body dynamically (for example, in Postman), ensure the body is sent as JSON rather than plain text.
 

--- a/pocketllm-backend/tests/test_api_key_validation.py
+++ b/pocketllm-backend/tests/test_api_key_validation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
 from typing import Any
 
 import httpx
@@ -54,6 +55,42 @@ def test_validate_groq_falls_back_to_http_when_sdk_missing(monkeypatch: pytest.M
     assert captured_timeouts and captured_timeouts[0] == 5.0
 
 
+def test_validate_groq_http_fallback_appends_openai_prefix(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure bare Groq base URLs gain the OpenAI compatibility prefix."""
+
+    real_async_client = httpx.AsyncClient
+    captured_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured_urls.append(str(request.url))
+        return httpx.Response(200, json={"data": []})
+
+    transport = httpx.MockTransport(handler)
+
+    @asynccontextmanager
+    async def client_factory(*args: Any, **kwargs: Any):
+        kwargs.setdefault("transport", transport)
+        async with real_async_client(*args, **kwargs) as client:
+            yield client
+
+    monkeypatch.setattr("app.services.api_keys.AsyncGroq", None, raising=False)
+    monkeypatch.setattr("app.services.api_keys.httpx.AsyncClient", client_factory, raising=False)
+
+    service = APIKeyValidationService(Settings())
+
+    asyncio.run(
+        service.validate(
+            "groq",
+            "test-key",
+            base_url="https://api.groq.com",
+            metadata={},
+        )
+    )
+
+    assert captured_urls
+    assert captured_urls[0].endswith("/openai/v1/models")
+
+
 def test_validate_groq_http_fallback_raises_for_errors(monkeypatch: pytest.MonkeyPatch) -> None:
     """HTTP fallback should surface non-success status codes as validation errors."""
 
@@ -79,3 +116,36 @@ def test_validate_groq_http_fallback_raises_for_errors(monkeypatch: pytest.Monke
         asyncio.run(service.validate("groq", "invalid", metadata={}))
 
     assert "403" in str(excinfo.value)
+
+
+def test_validate_groq_sdk_normalises_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The SDK validation path should strip redundant OpenAI prefixes."""
+
+    created_kwargs: dict[str, Any] = {}
+
+    class FakeGroqClient:
+        def __init__(self, **kwargs: Any) -> None:
+            created_kwargs.update(kwargs)
+            self.models = SimpleNamespace(list=self._list)
+
+        async def _list(self) -> Any:
+            return {"data": []}
+
+        async def aclose(self) -> None:  # pragma: no cover - exercised implicitly
+            return None
+
+    monkeypatch.setattr("app.services.api_keys.AsyncGroq", FakeGroqClient, raising=False)
+
+    service = APIKeyValidationService(Settings())
+
+    asyncio.run(
+        service.validate(
+            "groq",
+            "test-key",
+            base_url="https://proxy.example.com/openai/v1/",
+            metadata={"timeout": 1},
+        )
+    )
+
+    assert created_kwargs.get("api_key") == "test-key"
+    assert created_kwargs.get("base_url") == "https://proxy.example.com"

--- a/pocketllm-backend/tests/test_provider_catalogue.py
+++ b/pocketllm-backend/tests/test_provider_catalogue.py
@@ -507,6 +507,26 @@ async def test_groq_provider_client_uses_sdk_payload(caplog):
 
 
 @pytest.mark.asyncio
+async def test_groq_provider_client_normalises_base_url():
+    factory_calls: list[Mapping[str, Any]] = []
+
+    def factory(**kwargs: Any) -> FakeGroqClient:
+        factory_calls.append(kwargs)
+        return FakeGroqClient({"data": []})
+
+    settings = make_settings(
+        groq_api_key="test-key",
+        groq_api_base="https://proxy.example.com/openai/v1/",
+    )
+    client = GroqProviderClient(settings, client_factory=factory)
+
+    await client.list_models()
+
+    assert factory_calls
+    assert factory_calls[0].get("base_url") == "https://proxy.example.com"
+
+
+@pytest.mark.asyncio
 async def test_groq_provider_client_handles_sdk_errors(caplog):
     error = RuntimeError("boom")
 


### PR DESCRIPTION
## Summary
- normalise Groq SDK base URLs to avoid duplicating the /openai/v1 prefix during validation and provider calls
- ensure the HTTP fallback appends Groq's OpenAI-compatible path and update the provider default base URL
deep
- add regression tests covering Groq base URL normalisation and document the simplified configuration guidance

## Testing
- pytest tests/test_api_key_validation.py tests/test_provider_catalogue.py *(fails: missing pytest-asyncio plugin in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e38dcddb14832d9a24b30c85c64610