### PR TITLE
Handle flexible encryption keys and default provider configuration

### DIFF
--- a/pocketllm-backend/tests/test_crypto.py
+++ b/pocketllm-backend/tests/test_crypto.py
@@ -34,8 +34,18 @@ def test_encrypt_decrypt_with_raw_32_char_key(secret: str) -> None:
     assert decrypt_secret(token, settings) == secret
 
 
+def test_encrypt_decrypt_with_arbitrary_length_key() -> None:
+    settings = _Settings(
+        encryption_key="bj1-8kO9s993W4D7mJ3yVv6bB5gB7x4xL3dY2qV5mQ8kbh"
+    )
+
+    token = encrypt_secret("super-secret", settings)
+
+    assert decrypt_secret(token, settings) == "super-secret"
+
+
 def test_encrypt_with_invalid_key_raises() -> None:
-    settings = _Settings(encryption_key="short")
+    settings = _Settings(encryption_key="")
 
     with pytest.raises(RuntimeError):
         encrypt_secret("secret", settings)


### PR DESCRIPTION
## Summary
- allow the encryption utility to automatically pad or derive Fernet keys so arbitrary-length secrets such as the provided ENCRYPTION_KEY can be used
- default known provider activation requests to backend-managed base URLs while storing merged metadata
- add regression tests covering the new encryption fallback and Groq activation defaults

## Testing
- `pytest tests/test_crypto.py tests/test_provider_configs.py`

------
https://chatgpt.com/codex/tasks/task_e_68e391af3778832d8cc0989642ea235c