### PR TITLE
Improve provider defaults and encryption key handling

### DIFF
--- a/pocketllm-backend/tests/test_crypto.py
+++ b/pocketllm-backend/tests/test_crypto.py
@@ -39,3 +39,19 @@ def test_encrypt_with_invalid_key_raises() -> None:
 
     with pytest.raises(RuntimeError):
         encrypt_secret("secret", settings)
+
+
+@pytest.mark.parametrize(
+    "secret",
+    [
+        "value",
+        "another secret",
+    ],
+)
+def test_encrypt_decrypt_with_long_non_base64_key(secret: str) -> None:
+    key = "bj1-8kO9s993W4D7mJ3yVv6bB5gB7x4xL3dY2qV5mQ8kbh"
+    settings = _Settings(encryption_key=key)
+
+    token = encrypt_secret(secret, settings)
+
+    assert decrypt_secret(token, settings) == secret

--- a/pocketllm-backend/tests/test_provider_configs.py
+++ b/pocketllm-backend/tests/test_provider_configs.py
@@ -5,15 +5,25 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from types import SimpleNamespace
 from typing import Any
-from unittest.mock import Mock
-from uuid import uuid4
+from unittest.mock import AsyncMock, Mock
+from uuid import UUID, uuid4
 
 import pytest
 
 pytest.importorskip("pydantic")
 
-from app.schemas.providers import ProviderUpdateRequest
+from cryptography.fernet import Fernet
+
+from app.schemas.providers import ProviderActivationRequest, ProviderUpdateRequest
 from app.services.provider_configs import ProvidersService
+from app.services.providers import GroqProviderClient, OpenRouterProviderClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """Force AnyIO tests to run with asyncio only."""
+
+    return "asyncio"
 
 
 class _StubDatabase:
@@ -37,7 +47,35 @@ class _StubDatabase:
         return [merged]
 
 
-@pytest.mark.asyncio
+class _ActivationDatabaseStub:
+    """Capture provider payloads written during activation."""
+
+    def __init__(self) -> None:
+        self.last_upsert: dict[str, Any] | None = None
+
+    async def upsert(self, _table: str, data: dict[str, Any], *, on_conflict: str) -> list[dict[str, Any]]:
+        self.last_upsert = data
+        now = datetime.now(timezone.utc)
+        user_id = UUID(data["user_id"])
+        return [
+            {
+                "id": uuid4(),
+                "user_id": user_id,
+                "provider": data["provider"],
+                "display_name": data.get("display_name"),
+                "base_url": data.get("base_url"),
+                "metadata": data.get("metadata"),
+                "api_key_hash": data.get("api_key_hash"),
+                "api_key_preview": data.get("api_key_preview"),
+                "api_key_encrypted": data.get("api_key_encrypted"),
+                "is_active": data.get("is_active", False),
+                "created_at": now,
+                "updated_at": now,
+            }
+        ]
+
+
+@pytest.mark.anyio("asyncio")
 async def test_update_provider_clears_api_key_when_null() -> None:
     user_id = uuid4()
     record = {
@@ -72,3 +110,57 @@ async def test_update_provider_clears_api_key_when_null() -> None:
     assert result.api_key_preview is None
     assert result.has_api_key is False
 
+
+@pytest.mark.anyio("asyncio")
+async def test_activate_provider_applies_default_groq_configuration(monkeypatch) -> None:
+    settings = SimpleNamespace(
+        encryption_key=Fernet.generate_key().decode("utf-8"),
+        openai_api_base=None,
+        groq_api_base=None,
+        openrouter_api_base=None,
+        openrouter_app_url=None,
+        openrouter_app_name=None,
+    )
+    database = _ActivationDatabaseStub()
+    service = ProvidersService(settings, database, catalogue=Mock())
+    monkeypatch.setattr("app.services.provider_configs.hash_secret", lambda value: "hash")
+    monkeypatch.setattr("app.services.provider_configs.mask_secret", lambda value: "mask")
+    validate_mock = AsyncMock(return_value=None)
+    service._validator.validate = validate_mock  # type: ignore[assignment]
+
+    payload = ProviderActivationRequest(provider="groq", api_key="gsk_" + "x" * 48)
+    response = await service.activate_provider(uuid4(), payload)
+
+    validate_mock.assert_awaited_once()
+    assert validate_mock.await_args.kwargs["base_url"] == GroqProviderClient.default_base_url
+    assert database.last_upsert is not None
+    assert database.last_upsert["base_url"] == GroqProviderClient.default_base_url
+    assert database.last_upsert["metadata"] == {}
+    assert response.provider.base_url == GroqProviderClient.default_base_url
+
+
+@pytest.mark.anyio("asyncio")
+async def test_activate_provider_populates_openrouter_defaults(monkeypatch) -> None:
+    settings = SimpleNamespace(
+        encryption_key=Fernet.generate_key().decode("utf-8"),
+        openai_api_base=None,
+        groq_api_base=None,
+        openrouter_api_base=None,
+        openrouter_app_url="https://app.example",
+        openrouter_app_name="PocketLLM",
+    )
+    database = _ActivationDatabaseStub()
+    service = ProvidersService(settings, database, catalogue=Mock())
+    monkeypatch.setattr("app.services.provider_configs.hash_secret", lambda value: "hash")
+    monkeypatch.setattr("app.services.provider_configs.mask_secret", lambda value: "mask")
+    validate_mock = AsyncMock(return_value=None)
+    service._validator.validate = validate_mock  # type: ignore[assignment]
+
+    payload = ProviderActivationRequest(provider="openrouter", api_key="ork_" + "y" * 48)
+    await service.activate_provider(uuid4(), payload)
+
+    validate_mock.assert_awaited_once()
+    assert validate_mock.await_args.kwargs["base_url"] == OpenRouterProviderClient.default_base_url
+    metadata = database.last_upsert["metadata"]
+    assert metadata["http_referer"] == "https://app.example"
+    assert metadata["x_title"] == "PocketLLM"


### PR DESCRIPTION
## Summary
- allow the crypto helper to derive a Fernet key from sufficiently long strings when the configured key is not base64 encoded
- default provider activation to known base URLs and metadata instead of requiring the client to send them explicitly
- add focused tests covering the crypto fallback behaviour and the provider activation defaults

## Testing
- pytest tests/test_crypto.py tests/test_provider_configs.py

------
https://chatgpt.com/codex/tasks/task_e_68e391af3778832d8cc0989642ea235c