### PR TITLE
Fix ImageRouter API endpoints

### DIFF
--- a/pocketllm-backend/app/services/api_keys.py
+++ b/pocketllm-backend/app/services/api_keys.py
@@ -150,7 +150,15 @@ class APIKeyValidationService:
         base_url: str | None,
         metadata: Mapping[str, Any] | None,
     ) -> None:
-        url = (base_url or "https://api.imagerouter.io/v1/openai") + "/models"
+        base = (base_url or "https://api.imagerouter.io").rstrip("/")
+        lowered_base = base.lower()
+        if lowered_base.endswith("/v1/openai"):
+            base = base[: -len("/openai")]
+            lowered_base = base.lower()
+        if lowered_base.endswith("/v1"):
+            url = _join_url_path(base, "models")
+        else:
+            url = _join_url_path(base, "v1/models")
         headers = {"Authorization": f"Bearer {api_key}", "Accept": "application/json"}
         if metadata and isinstance(metadata.get("headers"), Mapping):
             headers.update({str(k): str(v) for k, v in metadata["headers"].items()})

--- a/pocketllm-backend/app/services/providers/imagerouter.py
+++ b/pocketllm-backend/app/services/providers/imagerouter.py
@@ -17,7 +17,8 @@ class ImageRouterProviderClient(ProviderClient):
     """ImageRouter provider client for image generation models."""
 
     provider = "imagerouter"
-    default_base_url = "https://api.imagerouter.io/v1/openai"
+    default_base_url = "https://api.imagerouter.io"
+    models_endpoint = "/v1/models"
 
     def __init__(
         self,
@@ -61,7 +62,7 @@ class ImageRouterProviderClient(ProviderClient):
                 timeout=self.timeout,
                 transport=self._transport,
             ) as client:
-                response = await client.get("/models")
+                response = await client.get(self.models_endpoint)
                 response.raise_for_status()
                 return self._parse_models(response.json())
 
@@ -201,7 +202,7 @@ class ImageRouterProviderClient(ProviderClient):
                 timeout=self.timeout * 2,
                 transport=self._transport,
             ) as client:
-                response = await client.post("/images/generations", json=payload)
+                response = await client.post("/v1/openai/images/generations", json=payload)
                 response.raise_for_status()
                 return response.json()
 


### PR DESCRIPTION
## Summary
- update ImageRouter API key validation to use the correct base URL and models path
- align the ImageRouter provider client with the official base URL and endpoints for models and image generation

## Testing
- pytest *(fails: async tests require an async pytest plugin in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3a7ef8ab0832d942215e0e3a6af13