### PR TITLE
Fix ImageRouter model parsing

### DIFF
--- a/pocketllm-backend/tests/test_provider_catalogue.py
+++ b/pocketllm-backend/tests/test_provider_catalogue.py
@@ -912,6 +912,31 @@ async def test_imagerouter_provider_client_fetches_models_via_http():
 
 
 @pytest.mark.asyncio
+async def test_imagerouter_provider_client_handles_models_key():
+    payload = {
+        "models": [
+            {
+                "id": "imagerouter/image-beta",
+                "name": "Image Beta",
+                "quality_levels": ["standard", "high"],
+            }
+        ]
+    }
+
+    transport = httpx.MockTransport(lambda _: httpx.Response(200, json=payload))
+    settings = make_settings(imagerouter_api_key="image-key")
+    client = ImageRouterProviderClient(settings, transport=transport)
+
+    models = await client.list_models()
+
+    assert [model.id for model in models] == ["imagerouter/image-beta"]
+    assert models[0].metadata == {
+        "capabilities": ["image_generation"],
+        "quality_levels": ["standard", "high"],
+    }
+
+
+@pytest.mark.asyncio
 async def test_providers_service_filters_models_by_attributes():
     models = [
         ProviderModel(


### PR DESCRIPTION
## Summary
- normalise ImageRouter model catalogue parsing to support both `data` and `models` payload formats
- avoid dropping ImageRouter models when responses omit optional metadata and tighten metadata normalisation
- cover the new parsing behaviour with an async client regression test

## Testing
- pytest tests/test_provider_catalogue.py::test_imagerouter_provider_client_fetches_models_via_http tests/test_provider_catalogue.py::test_imagerouter_provider_client_handles_models_key *(fails: requires pytest-asyncio plugin in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3aa289260832dbf24f1f6f18237ee