### PR TITLE
Define missing section title builder in library page

### DIFF
--- a/lib/pages/library_page.dart
+++ b/lib/pages/library_page.dart
@@ -641,6 +641,25 @@ class _LibraryPageState extends State<LibraryPage> {
     );
   }
 
+  Widget _buildSectionTitle(String title) {
+    final theme = Theme.of(context);
+    final defaultStyle = const TextStyle(
+      fontSize: 18,
+      fontWeight: FontWeight.w600,
+    );
+
+    return Padding(
+      padding: const EdgeInsets.only(bottom: 4),
+      child: Text(
+        title,
+        style: theme.textTheme.titleMedium?.copyWith(
+              fontWeight: FontWeight.w600,
+            ) ??
+            defaultStyle,
+      ),
+    );
+  }
+
   Widget _buildInfoTile({
     required IconData icon,
     required String label,


### PR DESCRIPTION
## Summary
- add a reusable `_buildSectionTitle` helper to the library page to render section headers
- style the section title using the current theme while providing a sensible default

## Testing
- flutter test *(fails: `flutter` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e3e42b07ec832da808e0dcc059ef03