### PR TITLE
Fix model library parsing for new backend payload

### DIFF
--- a/lib/services/remote_model_service.dart
+++ b/lib/services/remote_model_service.dart
@@ -112,8 +112,35 @@ class RemoteModelService {
       query: queryParams.isEmpty ? null : queryParams,
     );
 
-    final models = (data as List?) ?? [];
-    return models
+    Iterable<dynamic> modelsPayload;
+    if (data is List) {
+      modelsPayload = data;
+    } else if (data is Map) {
+      final payloadMap = Map<String, dynamic>.from(data);
+      final models = payloadMap['models'];
+      if (models is List) {
+        modelsPayload = models;
+      } else if (models == null) {
+        debugPrint(
+          'RemoteModelService.getAvailableModels response missing "models" key: $payloadMap',
+        );
+        modelsPayload = const <dynamic>[];
+      } else {
+        throw BackendApiException(
+          -1,
+          'Invalid models payload received from server',
+        );
+      }
+    } else if (data == null) {
+      modelsPayload = const <dynamic>[];
+    } else {
+      throw BackendApiException(
+        -1,
+        'Unexpected response when fetching available models',
+      );
+    }
+
+    return modelsPayload
         .map((entry) {
           final raw = Map<String, dynamic>.from(entry as Map);
           final providerId = raw['provider'] as String? ?? provider?.backendId ?? '';


### PR DESCRIPTION
## Summary
- handle backend /models responses that wrap the catalogue in a `models` key
- add defensive logging and error messages for unexpected payloads when loading the model library

## Testing
- Not run (flutter is not available in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e3e991a4cc832d99ad57974dacce04