### PR TITLE
Add fallback catalogue support and refresh model library UI

### DIFF
--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -431,6 +431,22 @@ class AvailableModelOption {
   }
 }
 
+class AvailableModelsResponse {
+  final List<AvailableModelOption> models;
+  final String? message;
+  final List<String> configuredProviders;
+  final List<String> missingProviders;
+  final bool usingFallback;
+
+  const AvailableModelsResponse({
+    required this.models,
+    this.message,
+    this.configuredProviders = const <String>[],
+    this.missingProviders = const <String>[],
+    this.usingFallback = false,
+  });
+}
+
 // Model configuration class
 class ModelConfig {
   String id;

--- a/pocketllm-backend/app/data/static_models.py
+++ b/pocketllm-backend/app/data/static_models.py
@@ -1,0 +1,90 @@
+"""Helpers for loading the bundled fallback model catalogue."""
+
+from __future__ import annotations
+
+import json
+import logging
+from functools import lru_cache
+from importlib import resources as importlib_resources
+from pathlib import Path
+from typing import Any, Iterable
+
+from app.schemas.providers import ProviderModel
+
+_LOGGER = logging.getLogger("app.data.static_models")
+
+
+@lru_cache(maxsize=1)
+def load_static_models() -> tuple[ProviderModel, ...]:
+    """Return the static model catalogue shipped with the backend.
+
+    The deployed API occasionally runs without provider credentials configured.
+    In that case we expose a curated list of models so the mobile client can
+    still present a meaningful catalogue. The JSON file is cached after the
+    first read to avoid repeated disk access.
+    """
+
+    try:
+        payload = _read_catalogue_payload()
+    except FileNotFoundError:
+        _LOGGER.warning("Static model catalogue not found; falling back to empty list")
+        return tuple()
+    except Exception:  # pragma: no cover - defensive logging
+        _LOGGER.exception("Failed to load static model catalogue")
+        return tuple()
+
+    items: Iterable[Any]
+    if isinstance(payload, dict):
+        items = payload.get("models", []) or []
+    elif isinstance(payload, list):
+        items = payload
+    else:
+        _LOGGER.error("Unexpected payload type for static model catalogue: %s", type(payload))
+        return tuple()
+
+    models: list[ProviderModel] = []
+    for entry in items:
+        if not isinstance(entry, dict):
+            continue
+        try:
+            models.append(ProviderModel(**entry))
+        except Exception as exc:  # pragma: no cover - defensive logging
+            _LOGGER.debug("Skipping malformed fallback model entry: %s", exc)
+            continue
+
+    return tuple(models)
+
+
+def load_static_models_for_provider(provider: str) -> tuple[ProviderModel, ...]:
+    """Return static catalogue entries scoped to a single provider."""
+
+    provider_key = provider.lower()
+    return tuple(
+        model for model in load_static_models() if model.provider.lower() == provider_key
+    )
+
+
+def _read_catalogue_payload() -> Any:
+    """Load the static catalogue JSON from package data or the repository root."""
+
+    # Prefer a packaged resource so deployments that bundle the JSON alongside
+    # the application keep working when executed from a different directory.
+    try:
+        resource = importlib_resources.files("app.data").joinpath("modellist.json")
+        if resource.is_file():
+            with resource.open("r", encoding="utf-8") as handle:
+                return json.load(handle)
+    except (FileNotFoundError, ModuleNotFoundError, AttributeError):
+        pass
+
+    # Fallback to the repository layout used during local development.
+    project_root = Path(__file__).resolve().parents[2]
+    json_path = project_root / "modellist.json"
+    if json_path.is_file():
+        with json_path.open("r", encoding="utf-8") as handle:
+            return json.load(handle)
+
+    raise FileNotFoundError("modellist.json not found in expected locations")
+
+
+__all__ = ["load_static_models", "load_static_models_for_provider"]

--- a/pocketllm-backend/app/schemas/providers.py
+++ b/pocketllm-backend/app/schemas/providers.py
@@ -117,6 +117,7 @@ class ProviderModelsResponse(BaseModel):
     message: Optional[str] = None
     configured_providers: list[str] = Field(default_factory=list)
     missing_providers: list[str] = Field(default_factory=list)
+    using_fallback: bool = False
 
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add a cached static model catalogue loader and teach the providers service to fall back to it when live providers return no models
- extend the provider models response with a fallback indicator and plumb it through the client service
- refresh the model library search bar and surface backend catalogue messages in the UI, including fallback notices, and add coverage for the new backend paths

## Testing
- flutter analyze *(fails: flutter is not installed in the container)*
- flutter test *(fails: flutter is not installed in the container)*
- flutter build apk --debug *(fails: flutter is not installed in the container)*
- pytest *(fails: upstream tests require async plugins and expect Supabase logger output)*

------
https://chatgpt.com/codex/tasks/task_e_68e3eed6c8c8832dad0a20ccc66b8266