### PR TITLE
Improve provider catalogue resiliency and refresh model library UI

### DIFF
--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -192,6 +192,33 @@ extension ModelProviderExtension on ModelProvider {
     }
   }
 
+  String? get brandAsset {
+    switch (this) {
+      case ModelProvider.pocketLLM:
+        return 'assets/icons/logo2.png';
+      case ModelProvider.ollama:
+        return 'assets/brand_icons/ollama.png';
+      case ModelProvider.openAI:
+        return 'assets/brand_icons/openai.svg';
+      case ModelProvider.groq:
+        return 'assets/brand_icons/groq.svg';
+      case ModelProvider.anthropic:
+        return null;
+      case ModelProvider.openRouter:
+        return 'assets/brand_icons/openrouter.jpeg';
+      case ModelProvider.imageRouter:
+        return 'assets/brand_icons/hyperbrowser.svg';
+      case ModelProvider.mistral:
+        return null;
+      case ModelProvider.deepseek:
+        return null;
+      case ModelProvider.lmStudio:
+        return null;
+      case ModelProvider.googleAI:
+        return 'assets/brand_icons/gemini.svg';
+    }
+  }
+
   String get defaultBaseUrl {
     switch (this) {
       case ModelProvider.pocketLLM:

--- a/pocketllm-backend/app/core/config.py
+++ b/pocketllm-backend/app/core/config.py
@@ -84,7 +84,13 @@ class Settings(BaseSettings):
     imagerouter_api_key: str | None = Field(default=None, alias="IMAGEROUTER_API_KEY")
     imagerouter_api_base: str | None = Field(default=None, alias="IMAGEROUTER_API_BASE")
     provider_catalogue_cache_ttl: int = Field(
-        default=60, alias="PROVIDER_CATALOGUE_CACHE_TTL"
+        default=300, alias="PROVIDER_CATALOGUE_CACHE_TTL"
+    )
+    provider_catalogue_provider_timeout: float = Field(
+        default=4.0, alias="PROVIDER_CATALOGUE_PROVIDER_TIMEOUT"
+    )
+    provider_catalogue_total_timeout: float = Field(
+        default=8.0, alias="PROVIDER_CATALOGUE_TOTAL_TIMEOUT"
     )
 
 

--- a/pocketllm-backend/app/services/providers/base.py
+++ b/pocketllm-backend/app/services/providers/base.py
@@ -38,6 +38,19 @@ class ProviderClient(ABC):
         self._api_key_override = api_key
         self._metadata: dict[str, Any] = dict(metadata or {})
 
+        timeout_override = self._metadata.get("timeout")
+        try:
+            if timeout_override is not None:
+                timeout_value = float(timeout_override)
+                if timeout_value > 0:
+                    self.timeout = timeout_value
+        except (TypeError, ValueError):
+            self._logger.debug(
+                "Ignoring invalid timeout override %r for provider %s",
+                timeout_override,
+                self.provider,
+            )
+
     @property
     def base_url(self) -> str:
         """Return the base URL for the provider API."""

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ flutter:
   assets:
     - assets/avatar1.jpg
     - assets/avatar2.jpg
-    - assets/brand_icons/google.png
+    - assets/brand_icons/
     - assets/icons/logo.png
     - assets/icons/logo2.png
 


### PR DESCRIPTION
## Summary
- add concurrency-aware timeouts, cache tuning, and configurable limits to the provider catalogue service
- honour timeout metadata in the shared provider client base class and expose new timeout settings defaults
- refresh the Flutter model library page with loading states, provider summaries, branded avatars, and a polished card layout while wiring up brand assets

## Testing
- `pytest` *(fails: async pytest plugin not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f98cdd1c832da3732ba46c10f4c7