### PR TITLE
Improve provider catalogue resiliency and refresh model library UI

### DIFF
--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -192,6 +192,33 @@ extension ModelProviderExtension on ModelProvider {
     }
   }
 
+  String? get brandAsset {
+    switch (this) {
+      case ModelProvider.pocketLLM:
+        return 'assets/icons/logo2.png';
+      case ModelProvider.ollama:
+        return 'assets/brand_icons/ollama.png';
+      case ModelProvider.openAI:
+        return 'assets/brand_icons/openai.svg';
+      case ModelProvider.groq:
+        return 'assets/brand_icons/groq.svg';
+      case ModelProvider.anthropic:
+        return null;
+      case ModelProvider.openRouter:
+        return 'assets/brand_icons/openrouter.jpeg';
+      case ModelProvider.imageRouter:
+        return 'assets/brand_icons/hyperbrowser.svg';
+      case ModelProvider.mistral:
+        return null;
+      case ModelProvider.deepseek:
+        return null;
+      case ModelProvider.lmStudio:
+        return null;
+      case ModelProvider.googleAI:
+        return 'assets/brand_icons/gemini.svg';
+    }
+  }
+
   String get defaultBaseUrl {
     switch (this) {
       case ModelProvider.pocketLLM:

--- a/pocketllm-backend/app/core/config.py
+++ b/pocketllm-backend/app/core/config.py
@@ -84,7 +84,13 @@ class Settings(BaseSettings):
     imagerouter_api_key: str | None = Field(default=None, alias="IMAGEROUTER_API_KEY")
     imagerouter_api_base: str | None = Field(default=None, alias="IMAGEROUTER_API_BASE")
     provider_catalogue_cache_ttl: int = Field(
-        default=60, alias="PROVIDER_CATALOGUE_CACHE_TTL"
+        default=300, alias="PROVIDER_CATALOGUE_CACHE_TTL"
+    )
+    provider_catalogue_provider_timeout: float = Field(
+        default=4.0, alias="PROVIDER_CATALOGUE_PROVIDER_TIMEOUT"
+    )
+    provider_catalogue_total_timeout: float = Field(
+        default=8.0, alias="PROVIDER_CATALOGUE_TOTAL_TIMEOUT"
     )
 
 

--- a/pocketllm-backend/app/services/providers/base.py
+++ b/pocketllm-backend/app/services/providers/base.py
@@ -38,6 +38,19 @@ class ProviderClient(ABC):
         self._api_key_override = api_key
         self._metadata: dict[str, Any] = dict(metadata or {})
 
+        timeout_override = self._metadata.get("timeout")
+        try:
+            if timeout_override is not None:
+                timeout_value = float(timeout_override)
+                if timeout_value > 0:
+                    self.timeout = timeout_value
+        except (TypeError, ValueError):
+            self._logger.debug(
+                "Ignoring invalid timeout override %r for provider %s",
+                timeout_override,
+                self.provider,
+            )
+
     @property
     def base_url(self) -> str:
         """Return the base URL for the provider API."""

--- a/pocketllm-backend/app/services/providers/catalogue.py
+++ b/pocketllm-backend/app/services/providers/catalogue.py
@@ -36,7 +36,10 @@ class _CacheEntry:
 
 
 class ProviderModelCatalogue:
-    """Aggregate models across multiple provider clients."""
+    """Aggregate models across multiple provider clients with concurrency safeguards."""
+
+    PROVIDER_TIMEOUT = 4.0
+    TOTAL_TIMEOUT = 8.0
 
     def __init__(
         self,
@@ -59,8 +62,24 @@ class ProviderModelCatalogue:
             }
         )
         self._cache_ttl_seconds = self._coerce_ttl(
-            getattr(settings, "provider_catalogue_cache_ttl", 60)
+            getattr(settings, "provider_catalogue_cache_ttl", 300)
         )
+        self._provider_timeout = self._coerce_timeout(
+            getattr(settings, "provider_catalogue_provider_timeout", self.PROVIDER_TIMEOUT),
+            self.PROVIDER_TIMEOUT,
+        )
+        self._total_timeout = self._coerce_timeout(
+            getattr(settings, "provider_catalogue_total_timeout", self.TOTAL_TIMEOUT),
+            self.TOTAL_TIMEOUT,
+        )
+
+        if 0 < self._total_timeout < self._provider_timeout:
+            self._logger.warning(
+                "Total timeout %.2fs is smaller than provider timeout %.2fs; clamping provider timeout.",
+                self._total_timeout,
+                self._provider_timeout,
+            )
+            self._provider_timeout = self._total_timeout
 
     _cache: dict[str, "_CacheEntry"] = {}
     _locks: dict[str, asyncio.Lock] = {}
@@ -72,7 +91,14 @@ class ProviderModelCatalogue:
         """Return models from every configured provider."""
 
         clients = self._get_clients(providers)
-        return await self._gather_models(clients)
+        if not clients:
+            self._logger.warning("No provider clients available for catalogue lookup")
+            return []
+
+        if self._total_timeout > 0:
+            return await self._gather_models_with_deadline(clients, self._total_timeout)
+
+        return await self._gather_models_concurrent(clients)
 
     async def list_models_for_provider(
         self,
@@ -93,7 +119,17 @@ class ProviderModelCatalogue:
         if not clients:
             self._logger.warning("Provider %s is not configured for this user", provider)
             return []
-        return await self._gather_models(clients)
+
+        try:
+            return await asyncio.wait_for(
+                self._gather_models_concurrent(clients),
+                timeout=self._provider_timeout if self._provider_timeout > 0 else None,
+            )
+        except asyncio.TimeoutError:
+            self._logger.error(
+                "Provider %s catalogue fetch exceeded %.2fs timeout", provider, self._provider_timeout
+            )
+            return []
 
     def _get_clients(self, providers: Sequence[object] | None) -> list[ProviderClient]:
         if self._clients_override is not None:
@@ -104,12 +140,14 @@ class ProviderModelCatalogue:
             factory = self._client_factories.get(provider_name)
             if factory is None:
                 continue
+            metadata = dict(config.metadata or {})
+            metadata.setdefault("timeout", self._provider_timeout)
             clients.append(
                 factory(
                     self._settings,
                     base_url=config.base_url,
                     api_key=config.api_key,
-                    metadata=config.metadata,
+                    metadata=metadata,
                 )
             )
         return clients
@@ -215,17 +253,105 @@ class ProviderModelCatalogue:
 
         return fallbacks
 
-    async def _gather_models(self, clients: Sequence[ProviderClient]) -> list[ProviderModel]:
+    async def _gather_models_concurrent(self, clients: Sequence[ProviderClient]) -> list[ProviderModel]:
         if not clients:
             return []
-        tasks = [self._safe_list_models(client) for client in clients]
-        results = await asyncio.gather(*tasks)
+
+        tasks = [
+            self._fetch_with_timeout(client, self._resolve_client_timeout(client))
+            for client in clients
+        ]
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+
         models: list[ProviderModel] = []
-        for provider_models in results:
-            models.extend(provider_models)
+        for index, result in enumerate(results):
+            if isinstance(result, Exception):
+                client = clients[index]
+                self._logger.error(
+                    "Provider %s fetch failed with unexpected exception: %s",
+                    getattr(client, "provider", "unknown"),
+                    result,
+                )
+                continue
+            models.extend(result)
         return models
 
-    async def _safe_list_models(self, client: ProviderClient) -> list[ProviderModel]:
+    async def _gather_models_with_deadline(
+        self,
+        clients: Sequence[ProviderClient],
+        total_timeout: float,
+    ) -> list[ProviderModel]:
+        if not clients:
+            return []
+
+        task_pairs = [
+            (
+                client,
+                asyncio.create_task(
+                    self._fetch_with_timeout(
+                        client,
+                        self._resolve_client_timeout(client),
+                    )
+                ),
+            )
+            for client in clients
+        ]
+
+        tasks = [task for _, task in task_pairs]
+
+        all_tasks: set[asyncio.Task[Any]] = set(tasks)
+        pending: set[asyncio.Task[Any]] = set(all_tasks)
+        done: set[asyncio.Task[Any]] = set()
+        try:
+            done, pending = await asyncio.wait(
+                all_tasks,
+                timeout=total_timeout,
+                return_when=asyncio.ALL_COMPLETED,
+            )
+            if pending:
+                self._logger.error(
+                    (
+                        "Provider catalogue fetch exceeded %.2fs timeout; "
+                        "returning results from %d of %d providers."
+                    ),
+                    total_timeout,
+                    len(done),
+                    len(tasks),
+                )
+        finally:
+            if pending:
+                for task in pending:
+                    task.cancel()
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        models: list[ProviderModel] = []
+        for client, task in task_pairs:
+            if not task.done():
+                continue
+            try:
+                result = task.result()
+            except asyncio.CancelledError:
+                self._logger.debug(
+                    "Provider %s fetch was cancelled when the catalogue deadline expired",
+                    getattr(client, "provider", "unknown"),
+                )
+                continue
+            except Exception as exc:  # pragma: no cover - defensive catch-all
+                self._logger.error(
+                    "Provider %s fetch failed with unexpected exception: %s",
+                    getattr(client, "provider", "unknown"),
+                    exc,
+                )
+                continue
+            models.extend(result)
+
+        return models
+
+    async def _fetch_with_timeout(
+        self,
+        client: ProviderClient,
+        timeout: float,
+    ) -> list[ProviderModel]:
         cache_key = self._build_cache_key(client)
         cached = self._cache_lookup(cache_key)
         if cached is not None:
@@ -243,7 +369,17 @@ class ProviderModelCatalogue:
                 )
                 return cached
             try:
-                models = await client.list_models()
+                models = await asyncio.wait_for(
+                    client.list_models(),
+                    timeout=timeout if timeout > 0 else None,
+                )
+            except asyncio.TimeoutError:
+                self._logger.error(
+                    "Provider %s exceeded %.2fs timeout when fetching catalogue",
+                    client.provider,
+                    timeout,
+                )
+                models = []
             except Exception:  # pragma: no cover - defensive catch-all
                 self._logger.exception(
                     "Failed to fetch models from provider %s", client.provider
@@ -255,6 +391,25 @@ class ProviderModelCatalogue:
                 )
             self._store_cache(cache_key, models)
             return list(models)
+
+    def _resolve_client_timeout(self, client: ProviderClient) -> float:
+        metadata = getattr(client, "metadata", None)
+        if isinstance(metadata, Mapping):
+            candidate = metadata.get("timeout")
+            try:
+                if candidate is not None:
+                    value = float(candidate)
+                    return value if value > 0 else self._provider_timeout
+            except (TypeError, ValueError):
+                self._logger.debug(
+                    "Ignoring invalid timeout override %r for provider %s",
+                    candidate,
+                    client.provider,
+                )
+        timeout = getattr(client, "timeout", None)
+        if isinstance(timeout, (int, float)) and timeout > 0:
+            return float(timeout)
+        return self._provider_timeout
 
     @classmethod
     def clear_cache(cls) -> None:
@@ -327,6 +482,14 @@ class ProviderModelCatalogue:
         except (TypeError, ValueError):  # pragma: no cover - defensive cast
             return 0
         return max(ttl, 0)
+
+    @staticmethod
+    def _coerce_timeout(value: Any, default: float) -> float:
+        try:
+            timeout = float(value)
+        except (TypeError, ValueError):
+            return default
+        return timeout if timeout > 0 else default
 
 
 __all__ = ["ProviderModelCatalogue"]

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -87,7 +87,7 @@ flutter:
   assets:
     - assets/avatar1.jpg
     - assets/avatar2.jpg
-    - assets/brand_icons/google.png
+    - assets/brand_icons/
     - assets/icons/logo.png
     - assets/icons/logo2.png
 


### PR DESCRIPTION
## Summary
- add concurrency-aware timeouts, cache tuning, and configurable limits to the provider catalogue service while preserving partial results when the overall deadline elapses
- honour timeout metadata in the shared provider client base class and expose new timeout settings defaults
- refresh the Flutter model library page with loading states, provider summaries, branded avatars, and a polished card layout while wiring up brand assets

## Testing
- `pytest pocketllm-backend -q` *(fails: async pytest plugin not installed in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e3f98cdd1c832da3732ba46c10f4c7