### PR TITLE
Persist Supabase auth sessions via secure cookies

### DIFF
--- a/pocketllm-backend/app/schemas/auth.py
+++ b/pocketllm-backend/app/schemas/auth.py
@@ -135,7 +135,7 @@ class TokenPayload(BaseModel):
 class RefreshTokenRequest(BaseModel):
     """Request body for refreshing tokens."""
 
-    refresh_token: str
+    refresh_token: str | None = None
 
 
 class RefreshTokenResponse(BaseModel):

--- a/pocketllm-backend/app/services/auth.py
+++ b/pocketllm-backend/app/services/auth.py
@@ -119,6 +119,13 @@ class AuthService:
 
         self._require_supabase()
 
+        refresh_token = (payload.refresh_token or "").strip()
+        if not refresh_token:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Refresh token is required",
+            )
+
         async with httpx.AsyncClient(timeout=10.0) as client:
             response = await client.post(
                 f"{self._settings.supabase_url}/auth/v1/token?grant_type=refresh_token",
@@ -126,7 +133,7 @@ class AuthService:
                     "apikey": self._settings.supabase_anon_key,
                     "Authorization": f"Bearer {self._settings.supabase_anon_key}",
                 },
-                json={"refresh_token": payload.refresh_token},
+                json={"refresh_token": refresh_token},
             )
 
         if response.status_code >= 400:

--- a/pocketllm-backend/app/utils/auth_cookies.py
+++ b/pocketllm-backend/app/utils/auth_cookies.py
@@ -98,11 +98,32 @@ def get_refresh_token_from_request(request: Request) -> str | None:
     return None
 
 
+def get_access_token_from_request(request: Request) -> str | None:
+    """Extract an access token from request cookies or headers if available."""
+
+    cookie_candidates = (
+        request.cookies.get(ACCESS_COOKIE_NAME),
+        request.cookies.get("access_token"),
+    )
+    for token in cookie_candidates:
+        if token and token.strip():
+            return token.strip()
+
+    auth_header = request.headers.get("Authorization")
+    if auth_header and auth_header.strip():
+        scheme, _, token = auth_header.partition(" ")
+        if scheme.lower() == "bearer" and token.strip():
+            return token.strip()
+
+    return None
+
+
 __all__ = [
     "ACCESS_COOKIE_NAME",
     "REFRESH_COOKIE_NAME",
     "set_auth_cookies",
     "clear_auth_cookies",
     "get_refresh_token_from_request",
+    "get_access_token_from_request",
 ]
 

--- a/pocketllm-backend/app/utils/auth_cookies.py
+++ b/pocketllm-backend/app/utils/auth_cookies.py
@@ -1,0 +1,108 @@
+"""Helper utilities for managing authentication cookies."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Final
+
+from fastapi import Request, Response
+
+from app.core.config import Settings
+from app.schemas.auth import AuthTokens, SessionMetadata
+
+
+ACCESS_COOKIE_NAME: Final[str] = "sb-access-token"
+REFRESH_COOKIE_NAME: Final[str] = "sb-refresh-token"
+
+
+def _seconds_until(expiry: datetime) -> int:
+    """Return the number of whole seconds between now and ``expiry``."""
+
+    delta = expiry - datetime.now(tz=UTC)
+    seconds = int(delta.total_seconds())
+    return max(seconds, 1)
+
+
+def _refresh_expiry(session: SessionMetadata, settings: Settings) -> datetime:
+    """Determine the expiry timestamp for the refresh token cookie."""
+
+    if session.refresh_expires_at is not None:
+        return session.refresh_expires_at
+    refresh_minutes = getattr(settings, "refresh_token_expire_minutes", 0) or 0
+    if refresh_minutes <= 0:
+        refresh_minutes = 60 * 24 * 14  # fall back to Supabase default (14 days)
+    return session.expires_at + timedelta(minutes=refresh_minutes)
+
+
+def set_auth_cookies(
+    response: Response,
+    tokens: AuthTokens,
+    session: SessionMetadata,
+    settings: Settings,
+) -> None:
+    """Persist access and refresh tokens as secure HTTP-only cookies."""
+
+    secure = not settings.debug
+    same_site = "lax"
+
+    response.set_cookie(
+        ACCESS_COOKIE_NAME,
+        tokens.access_token,
+        max_age=_seconds_until(session.expires_at),
+        expires=session.expires_at,
+        httponly=True,
+        secure=secure,
+        samesite=same_site,
+        path="/",
+    )
+
+    refresh_token = (tokens.refresh_token or "").strip()
+    if not refresh_token:
+        return
+
+    refresh_expiry = _refresh_expiry(session, settings)
+    response.set_cookie(
+        REFRESH_COOKIE_NAME,
+        refresh_token,
+        max_age=_seconds_until(refresh_expiry),
+        expires=refresh_expiry,
+        httponly=True,
+        secure=secure,
+        samesite=same_site,
+        path="/",
+    )
+
+
+def clear_auth_cookies(response: Response) -> None:
+    """Remove authentication cookies from the client."""
+
+    response.delete_cookie(ACCESS_COOKIE_NAME, path="/")
+    response.delete_cookie(REFRESH_COOKIE_NAME, path="/")
+
+
+def get_refresh_token_from_request(request: Request) -> str | None:
+    """Extract a refresh token from request cookies or headers if available."""
+
+    cookie_candidates = (
+        request.cookies.get(REFRESH_COOKIE_NAME),
+        request.cookies.get("refresh_token"),
+    )
+    for token in cookie_candidates:
+        if token and token.strip():
+            return token.strip()
+
+    header_token = request.headers.get("X-Refresh-Token")
+    if header_token and header_token.strip():
+        return header_token.strip()
+
+    return None
+
+
+__all__ = [
+    "ACCESS_COOKIE_NAME",
+    "REFRESH_COOKIE_NAME",
+    "set_auth_cookies",
+    "clear_auth_cookies",
+    "get_refresh_token_from_request",
+]
+

--- a/pocketllm-backend/tests/test_auth_cookies.py
+++ b/pocketllm-backend/tests/test_auth_cookies.py
@@ -1,0 +1,72 @@
+"""Tests for authentication cookie helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from uuid import uuid4
+
+from fastapi import Response
+
+from app.core.config import Settings
+from app.schemas.auth import AuthTokens, SessionMetadata
+from app.utils.auth_cookies import (
+    ACCESS_COOKIE_NAME,
+    REFRESH_COOKIE_NAME,
+    clear_auth_cookies,
+    get_refresh_token_from_request,
+    set_auth_cookies,
+)
+
+
+def _build_session(expiry_minutes: int = 30, refresh_minutes: int = 60) -> SessionMetadata:
+    now = datetime.now(tz=UTC)
+    return SessionMetadata(
+        session_id=uuid4(),
+        expires_at=now + timedelta(minutes=expiry_minutes),
+        refresh_expires_at=now + timedelta(minutes=refresh_minutes),
+    )
+
+
+def test_set_auth_cookies_sets_secure_http_only_cookies() -> None:
+    settings = Settings(debug=False)
+    response = Response()
+    tokens = AuthTokens(access_token="access-token", refresh_token="refresh-token", expires_in=3600)
+    session = _build_session()
+
+    set_auth_cookies(response, tokens, session, settings)
+
+    cookies = response.headers.getlist("set-cookie")
+    assert any(cookie.startswith(f"{ACCESS_COOKIE_NAME}=access-token") for cookie in cookies)
+    refresh_cookie = next(cookie for cookie in cookies if cookie.startswith(f"{REFRESH_COOKIE_NAME}="))
+    assert "HttpOnly" in refresh_cookie
+    assert "Secure" in refresh_cookie
+    assert "SameSite=lax" in refresh_cookie
+
+
+def test_clear_auth_cookies_marks_cookies_for_removal() -> None:
+    response = Response()
+    clear_auth_cookies(response)
+
+    cookies = response.headers.getlist("set-cookie")
+    assert any(cookie.startswith(f"{ACCESS_COOKIE_NAME}=") for cookie in cookies)
+    assert all("Max-Age=0" in cookie for cookie in cookies)
+
+
+def test_get_refresh_token_from_request_prefers_cookie() -> None:
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.cookies = {REFRESH_COOKIE_NAME: "cookie-token"}
+            self.headers = {"X-Refresh-Token": "header-token"}
+
+    request = DummyRequest()
+    assert get_refresh_token_from_request(request) == "cookie-token"
+
+
+def test_get_refresh_token_from_request_falls_back_to_header() -> None:
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.cookies = {}
+            self.headers = {"X-Refresh-Token": " header-token "}
+
+    request = DummyRequest()
+    assert get_refresh_token_from_request(request) == "header-token"

--- a/pocketllm-backend/tests/test_auth_cookies.py
+++ b/pocketllm-backend/tests/test_auth_cookies.py
@@ -13,6 +13,7 @@ from app.utils.auth_cookies import (
     ACCESS_COOKIE_NAME,
     REFRESH_COOKIE_NAME,
     clear_auth_cookies,
+    get_access_token_from_request,
     get_refresh_token_from_request,
     set_auth_cookies,
 )
@@ -70,3 +71,33 @@ def test_get_refresh_token_from_request_falls_back_to_header() -> None:
 
     request = DummyRequest()
     assert get_refresh_token_from_request(request) == "header-token"
+
+
+def test_get_access_token_from_request_prefers_cookie() -> None:
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.cookies = {ACCESS_COOKIE_NAME: " cookie-token "}
+            self.headers = {"Authorization": "Bearer header-token"}
+
+    request = DummyRequest()
+    assert get_access_token_from_request(request) == "cookie-token"
+
+
+def test_get_access_token_from_request_handles_header() -> None:
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.cookies = {}
+            self.headers = {"Authorization": "Bearer header-token"}
+
+    request = DummyRequest()
+    assert get_access_token_from_request(request) == "header-token"
+
+
+def test_get_access_token_from_request_returns_none_when_missing() -> None:
+    class DummyRequest:
+        def __init__(self) -> None:
+            self.cookies = {}
+            self.headers = {}
+
+    request = DummyRequest()
+    assert get_access_token_from_request(request) is None


### PR DESCRIPTION
## Summary
- add dedicated helpers for issuing and clearing Supabase auth cookies
- set/clear cookies across auth endpoints and allow refresh tokens to fall back to cookies
- cover the cookie helpers with unit tests to ensure secure attributes and fallbacks

## Testing
- pytest tests/test_auth_cookies.py

------
https://chatgpt.com/codex/tasks/task_e_68e4a2043aac832db5b0990a36c45fb6