### PR TITLE
Handle Supabase token validation without shared secret

### DIFF
--- a/lib/services/api_endpoints.dart
+++ b/lib/services/api_endpoints.dart
@@ -30,7 +30,6 @@ class ApiEndpoints {
   static const List<String> defaultBaseUrls = <String>[
     defaultBackendBaseUrl,
     'https://pocket-llm-api.vercel.app',
-    'http://localhost:8000', // Local development fallback
   ];
 
   static String resolveBaseUrl([String? override]) {

--- a/lib/services/backend_api_service.dart
+++ b/lib/services/backend_api_service.dart
@@ -309,16 +309,7 @@ class BackendApiService {
       String.fromEnvironment('POCKETLLM_BACKEND_ROOT_URL', defaultValue: ''),
       String.fromEnvironment('BACKEND_BASE_URL', defaultValue: ''),
     ];
-
-    const fallbackEnvironmentCandidates = [
-      String.fromEnvironment('POCKETLLM_FALLBACK_BACKEND_URL', defaultValue: ''),
-      String.fromEnvironment('FALLBACK_BACKEND_URL', defaultValue: ''),
-    ];
-
-    final environmentCandidates = <String>[
-      ...primaryEnvironmentCandidates,
-      ...fallbackEnvironmentCandidates,
-    ];
+    final environmentCandidates = <String>[...primaryEnvironmentCandidates];
 
     final environmentOrder = <String>[];
     final environmentSet = <String>{};
@@ -338,9 +329,7 @@ class BackendApiService {
       }
     }
 
-    final merged = List.of(
-      ApiEndpoints.mergeBaseUrls(environmentCandidates),
-    );
+    final merged = List.of(ApiEndpoints.mergeBaseUrls(environmentCandidates));
 
     final ordered = <String>[];
     final seen = <String>{};

--- a/pocketllm-backend/app/utils/security.py
+++ b/pocketllm-backend/app/utils/security.py
@@ -3,6 +3,9 @@
 from __future__ import annotations
 
 from datetime import UTC, datetime
+from typing import Any, Mapping
+
+import httpx
 import jwt
 from fastapi import HTTPException, status
 from passlib.context import CryptContext
@@ -37,11 +40,22 @@ def mask_secret(secret: str, visible: int = 4) -> str:
 def decode_access_token(token: str, settings: Settings) -> TokenPayload:
     """Decode and validate a Supabase JWT access token."""
 
-    if not settings.supabase_jwt_secret:
-        raise HTTPException(status_code=status.HTTP_500_INTERNAL_SERVER_ERROR, detail="JWT secret not configured")
+    if settings.supabase_jwt_secret:
+        decoded = _decode_with_secret(token, settings)
+    else:
+        decoded = _decode_with_supabase_verification(token, settings)
+
+    payload = TokenPayload.model_validate(decoded)
+    if payload.exp < datetime.now(tz=UTC):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired")
+    return payload
+
+
+def _decode_with_secret(token: str, settings: Settings) -> Mapping[str, Any]:
+    """Decode a JWT using the configured Supabase secret."""
 
     try:
-        decoded = jwt.decode(
+        return jwt.decode(
             token,
             settings.supabase_jwt_secret,
             algorithms=[settings.token_algorithm],
@@ -52,10 +66,88 @@ def decode_access_token(token: str, settings: Settings) -> TokenPayload:
     except jwt.InvalidTokenError as exc:  # type: ignore[attr-defined]
         raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication token") from exc
 
-    payload = TokenPayload.model_validate(decoded)
-    if payload.exp < datetime.now(tz=UTC):
-        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token has expired")
+
+def _decode_with_supabase_verification(token: str, settings: Settings) -> Mapping[str, Any]:
+    """Validate a Supabase JWT when the shared secret is not configured."""
+
+    supabase_url = str(getattr(settings, "supabase_url", "")).rstrip("/")
+    api_key = getattr(settings, "supabase_anon_key", None) or getattr(settings, "supabase_service_role_key", None)
+
+    if not supabase_url or not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Supabase credentials are not configured",
+        )
+
+    auth_endpoint = f"{supabase_url}/auth/v1/user"
+    headers = {
+        "apikey": api_key,
+        "Authorization": f"Bearer {token}",
+    }
+
+    try:
+        response = httpx.get(auth_endpoint, headers=headers, timeout=5.0)
+        response.raise_for_status()
+    except httpx.HTTPStatusError as exc:
+        if exc.response.status_code in {status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN}:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid authentication token",
+            ) from exc
+        raise HTTPException(
+            status_code=status.HTTP_502_BAD_GATEWAY,
+            detail="Failed to validate authentication token with Supabase",
+        ) from exc
+    except httpx.RequestError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Unable to contact Supabase for token validation",
+        ) from exc
+
+    user_data = response.json()
+
+    try:
+        unverified = jwt.decode(token, options={"verify_signature": False})
+    except jwt.InvalidTokenError as exc:  # type: ignore[attr-defined]
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid authentication token") from exc
+
+    exp = _coerce_timestamp(unverified.get("exp"))
+    if exp is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token is missing an expiry")
+
+    payload: dict[str, Any] = {
+        "sub": user_data.get("id") or unverified.get("sub"),
+        "email": user_data.get("email") or unverified.get("email"),
+        "role": user_data.get("role") or unverified.get("role"),
+        "aud": user_data.get("aud") or unverified.get("aud"),
+        "exp": exp,
+        "iat": _coerce_timestamp(unverified.get("iat")),
+        "iss": unverified.get("iss"),
+        "session_id": unverified.get("session_id") or user_data.get("session_id"),
+    }
+
+    if not payload.get("sub"):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token is missing a subject")
+
     return payload
+
+
+def _coerce_timestamp(value: Any) -> datetime | None:
+    """Convert a JWT timestamp into an aware ``datetime`` instance."""
+
+    if value is None:
+        return None
+
+    if isinstance(value, (int, float)):
+        return datetime.fromtimestamp(value, tz=UTC)
+
+    if isinstance(value, str) and value.isdigit():
+        return datetime.fromtimestamp(int(value), tz=UTC)
+
+    if isinstance(value, datetime):
+        return value if value.tzinfo else value.replace(tzinfo=UTC)
+
+    raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token timestamp")
 
 
 def create_supabase_service_headers(settings: Settings) -> dict[str, str]:
@@ -67,4 +159,10 @@ def create_supabase_service_headers(settings: Settings) -> dict[str, str]:
     }
 
 
-__all__ = ["hash_secret", "verify_secret", "mask_secret", "decode_access_token", "create_supabase_service_headers"]
+__all__ = [
+    "hash_secret",
+    "verify_secret",
+    "mask_secret",
+    "decode_access_token",
+    "create_supabase_service_headers",
+]

--- a/pocketllm-backend/tests/test_security_utils.py
+++ b/pocketllm-backend/tests/test_security_utils.py
@@ -1,0 +1,72 @@
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+import jwt
+
+from app.utils.security import decode_access_token
+
+
+class _StubResponse:
+    """Minimal stub emulating an ``httpx.Response`` for success cases."""
+
+    def __init__(self, payload: dict[str, object]) -> None:
+        self._payload = payload
+        self.status_code = 200
+
+    def raise_for_status(self) -> None:  # pragma: no cover - no-op for success
+        return None
+
+    def json(self) -> dict[str, object]:
+        return dict(self._payload)
+
+
+def test_decode_access_token_uses_supabase_verification(monkeypatch) -> None:
+    """Fallback validation should succeed when the JWT secret is missing."""
+
+    user_id = uuid4()
+    issued_at = datetime.now(tz=UTC) - timedelta(minutes=1)
+    expires_at = issued_at + timedelta(hours=1)
+
+    token_payload = {
+        "sub": str(user_id),
+        "email": "user@example.com",
+        "role": "authenticated",
+        "aud": "authenticated",
+        "iat": int(issued_at.timestamp()),
+        "exp": int(expires_at.timestamp()),
+        "iss": "https://example.supabase.co/auth/v1",
+    }
+
+    token = jwt.encode(token_payload, "arbitrary-secret", algorithm="HS256")
+
+    supabase_user_payload = {
+        "id": str(user_id),
+        "email": "user@example.com",
+        "role": "authenticated",
+        "aud": "authenticated",
+    }
+
+    def _fake_get(url: str, *, headers: dict[str, str], timeout: float) -> _StubResponse:
+        assert url == "https://example.supabase.co/auth/v1/user"
+        assert "Authorization" in headers and headers["Authorization"].startswith("Bearer ")
+        return _StubResponse(supabase_user_payload)
+
+    monkeypatch.setattr("httpx.get", _fake_get)
+
+    settings = SimpleNamespace(
+        supabase_jwt_secret=None,
+        supabase_url="https://example.supabase.co",
+        supabase_anon_key="anon-key",
+        supabase_service_role_key="service-role",
+        token_algorithm="HS256",
+        supabase_jwt_audience="authenticated",
+    )
+
+    payload = decode_access_token(token, settings)
+
+    assert payload.sub == user_id
+    assert payload.email == "user@example.com"
+    assert payload.role == "authenticated"
+    assert payload.aud == "authenticated"
+    assert payload.exp == expires_at.replace(microsecond=0)


### PR DESCRIPTION
## Summary
- allow the API to validate Supabase access tokens via the Supabase REST API when the JWT secret is not configured
- add coverage for the new token validation fallback logic
- remove the hard-coded localhost backend fallback from the Flutter client configuration

## Testing
- pytest tests/test_security_utils.py

------
https://chatgpt.com/codex/tasks/task_e_68e4d5cb2710832da72b603c417fd524