### PR TITLE
Improve Supabase startup diagnostics and allow optional strict mode

### DIFF
--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -38,6 +38,8 @@ ENCRYPTION_KEY=<fernet-key-or-32-char-secret>
 LOG_LEVEL=INFO
 # Optional: bypass the Supabase connectivity check when running offline/local tests
 SUPABASE_SKIP_CONNECTION_TEST=false
+# Optional: continue booting when Supabase is unreachable (defaults to false)
+SUPABASE_STRICT_STARTUP=false
 ```
 
 Refer to [`API_DOCUMENTATION.md`](API_DOCUMENTATION.md) for the full list of optional settings.
@@ -52,7 +54,12 @@ If a raw 32-character string is supplied, the backend will automatically derive 
 When developing locally without network access to Supabase you can set
 `SUPABASE_SKIP_CONNECTION_TEST=true`. This allows the API server to boot
 without performing the startup connectivity probe while keeping runtime
-behaviour unchanged for production deployments.
+behaviour unchanged for production deployments. If the connectivity check
+fails, the backend now logs detailed diagnostics (including DNS resolution
+results) and continues to start unless `SUPABASE_STRICT_STARTUP` is set to a
+truthy value, in which case the application exits immediately. This makes it
+easy to run the API offline while still enforcing strict guarantees in staging
+or production.
 
 ### 3. Initialise the database schema
 


### PR DESCRIPTION
## Summary
- add Supabase connection metadata tracking, DNS diagnostics, and a configurable strict startup gate
- update the async database adapter to respect the relaxed startup mode and surface detailed connection failures
- document the SUPABASE_STRICT_STARTUP flag and cover the behaviour with new regression tests

## Testing
- pytest tests/test_database_supabase_rest.py::test_startup_allows_unverified_connection_when_not_strict tests/test_database_supabase_rest.py::test_startup_raises_when_strict_and_connection_fails
- pytest tests/test_database_supabase_rest.py
- pytest *(fails: environment lacks an async test plugin)*

------
https://chatgpt.com/codex/tasks/task_e_6901ec7f7ca8832dbbc6615f92201ebf