### PR TITLE
Handle Supabase auth failures when offline

### DIFF
--- a/pocketllm-backend/README.md
+++ b/pocketllm-backend/README.md
@@ -38,6 +38,8 @@ ENCRYPTION_KEY=<fernet-key-or-32-char-secret>
 LOG_LEVEL=INFO
 # Optional: bypass the Supabase connectivity check when running offline/local tests
 SUPABASE_SKIP_CONNECTION_TEST=false
+# Optional: continue booting when Supabase is unreachable (defaults to false)
+SUPABASE_STRICT_STARTUP=false
 ```
 
 Refer to [`API_DOCUMENTATION.md`](API_DOCUMENTATION.md) for the full list of optional settings.
@@ -52,7 +54,12 @@ If a raw 32-character string is supplied, the backend will automatically derive 
 When developing locally without network access to Supabase you can set
 `SUPABASE_SKIP_CONNECTION_TEST=true`. This allows the API server to boot
 without performing the startup connectivity probe while keeping runtime
-behaviour unchanged for production deployments.
+behaviour unchanged for production deployments. If the connectivity check
+fails, the backend now logs detailed diagnostics (including DNS resolution
+results) and continues to start unless `SUPABASE_STRICT_STARTUP` is set to a
+truthy value, in which case the application exits immediately. This makes it
+easy to run the API offline while still enforcing strict guarantees in staging
+or production.
 
 ### 3. Initialise the database schema
 

--- a/pocketllm-backend/tests/test_auth_service.py
+++ b/pocketllm-backend/tests/test_auth_service.py
@@ -1,0 +1,56 @@
+import asyncio
+import httpx
+import pytest
+from fastapi import HTTPException, status
+
+from app.core.config import Settings
+from app.services.auth import AuthService
+from app.schemas.auth import SignInRequest
+
+
+class DummyDatabase:
+    async def upsert_profile(self, user_id, payload):  # pragma: no cover - test double
+        return None
+
+    async def get_profile(self, user_id):  # pragma: no cover - test double
+        return None
+
+    async def select(self, *args, **kwargs):  # pragma: no cover - compatibility stub
+        return []
+
+
+class FailingAsyncClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, *args, **kwargs):
+        raise httpx.ConnectError(
+            "Unable to resolve Supabase host",
+            request=httpx.Request("POST", "https://project.supabase.co/auth/v1/token"),
+        )
+
+
+def test_sign_in_returns_service_unavailable_when_supabase_unreachable(monkeypatch):
+    settings = Settings(
+        supabase_url="https://project.supabase.co",
+        supabase_anon_key="anon",
+        supabase_service_role_key="service",
+    )
+    service = AuthService(settings=settings, database=DummyDatabase())
+
+    monkeypatch.setattr(httpx, "AsyncClient", FailingAsyncClient)
+
+    async def run() -> None:
+        with pytest.raises(HTTPException) as exc_info:
+            await service.sign_in(SignInRequest(email="user@example.com", password="secret"))
+
+        assert exc_info.value.status_code == status.HTTP_503_SERVICE_UNAVAILABLE
+        assert "temporarily unavailable" in exc_info.value.detail
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- wrap Supabase authentication requests in defensive error handling so connection failures raise a user-friendly 503 response
- log connection errors and update the auth service to surface a consistent outage message instead of raw HTTPX exceptions
- add a regression test that exercises the sign-in path when the Supabase host cannot be resolved

## Testing
- pytest pocketllm-backend/tests/test_auth_service.py


------
https://chatgpt.com/codex/tasks/task_e_6901ec7f7ca8832dbbc6615f92201ebf