### PR TITLE
Fix non-const iOS secure storage options

### DIFF
--- a/lib/component/onboarding_screens/onboarding_screen.dart
+++ b/lib/component/onboarding_screens/onboarding_screen.dart
@@ -406,7 +406,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       key: 'provider_api_key_${option.id}',
       value: value,
       aOptions: const AndroidOptions(encryptedSharedPreferences: true),
-      iOptions: const IOSOptions(accessibility: IOSAccessibility.first_unlock_this_device_only),
+      iOptions:
+          IOSOptions(accessibility: IOSAccessibility.first_unlock_this_device_only),
     );
 
     setState(() {
@@ -427,7 +428,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     await _secureStorage.delete(
       key: 'provider_api_key_${option.id}',
       aOptions: const AndroidOptions(encryptedSharedPreferences: true),
-      iOptions: const IOSOptions(
+      iOptions: IOSOptions(
         accessibility: IOSAccessibility.first_unlock_this_device_only,
       ),
     );


### PR DESCRIPTION
## Summary
- remove the const constructor usage when creating IOSOptions for secure storage calls in the onboarding screen to avoid runtime errors

## Testing
- flutter test *(fails: Flutter SDK unavailable in environment)*

------
https://chatgpt.com/codex/tasks/task_e_690202a8c3d8832d9982fb56ca2edcc3