### PR TITLE
Fix missing iOS accessibility import

### DIFF
--- a/lib/component/onboarding_screens/onboarding_screen.dart
+++ b/lib/component/onboarding_screens/onboarding_screen.dart
@@ -2,6 +2,8 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart'
+    show IOSAccessibility;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../pages/auth/auth_flow_screen.dart';
@@ -406,7 +408,8 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       key: 'provider_api_key_${option.id}',
       value: value,
       aOptions: const AndroidOptions(encryptedSharedPreferences: true),
-      iOptions: const IOSOptions(accessibility: IOSAccessibility.first_unlock_this_device_only),
+      iOptions:
+          IOSOptions(accessibility: IOSAccessibility.first_unlock_this_device_only),
     );
 
     setState(() {
@@ -427,7 +430,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
     await _secureStorage.delete(
       key: 'provider_api_key_${option.id}',
       aOptions: const AndroidOptions(encryptedSharedPreferences: true),
-      iOptions: const IOSOptions(
+      iOptions: IOSOptions(
         accessibility: IOSAccessibility.first_unlock_this_device_only,
       ),
     );

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -383,7 +383,7 @@ packages:
     source: hosted
     version: "3.1.3"
   flutter_secure_storage_platform_interface:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: flutter_secure_storage_platform_interface
       sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   url_launcher: ^6.2.4
   permission_handler: ^11.0.1
   flutter_secure_storage: ^9.0.0
+  flutter_secure_storage_platform_interface: ^1.1.2
   timeago: ^3.6.0
   ollama_dart: ^0.0.2
   flutter_bloc: ^8.1.4


### PR DESCRIPTION
## Summary
- import IOSAccessibility from the flutter_secure_storage platform interface so the onboarding screen can reference the enum

## Testing
- not run (Flutter SDK unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_690202a8c3d8832d9982fb56ca2edcc3