### PR TITLE
Fix Android SDK level and secure storage compatibility

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 
 android {
     namespace = "com.example.pocketllm"
-    compileSdk = 35
+    compileSdk = 36
     ndkVersion = "27.0.12077973"
 
     compileOptions {

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,7 +19,7 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.0" apply false
-    id("org.jetbrains.kotlin.android") version "1.8.22" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
 }
 
 include(":app")

--- a/lib/component/onboarding_screens/onboarding_screen.dart
+++ b/lib/component/onboarding_screens/onboarding_screen.dart
@@ -408,8 +408,9 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       key: 'provider_api_key_${option.id}',
       value: value,
       aOptions: const AndroidOptions(encryptedSharedPreferences: true),
-      iOptions:
-          IOSOptions(accessibility: IOSAccessibility.first_unlock_this_device_only),
+      iOptions: IOSOptions(
+        accessibility: _firstUnlockThisDeviceOnlyAccessibility,
+      ),
     );
 
     setState(() {
@@ -431,7 +432,7 @@ class _OnboardingScreenState extends State<OnboardingScreen> {
       key: 'provider_api_key_${option.id}',
       aOptions: const AndroidOptions(encryptedSharedPreferences: true),
       iOptions: IOSOptions(
-        accessibility: IOSAccessibility.first_unlock_this_device_only,
+        accessibility: _firstUnlockThisDeviceOnlyAccessibility,
       ),
     );
     setState(() {
@@ -629,3 +630,27 @@ class _QuickLink extends StatelessWidget {
     );
   }
 }
+final IOSAccessibility _firstUnlockThisDeviceOnlyAccessibility =
+    _resolveFirstUnlockThisDeviceOnly();
+
+IOSAccessibility _resolveFirstUnlockThisDeviceOnly() {
+  IOSAccessibility? matched;
+  for (final option in IOSAccessibility.values) {
+    switch (option.name) {
+      case 'first_unlock_this_device_only':
+      case 'first_unlockThisDeviceOnly':
+      case 'firstUnlockThisDeviceOnly':
+      case 'afterFirstUnlockThisDeviceOnly':
+        return option;
+      case 'first_unlock':
+      case 'firstUnlock':
+      case 'afterFirstUnlock':
+        matched ??= option;
+        break;
+      default:
+        break;
+    }
+  }
+  return matched ?? IOSAccessibility.values.first;
+}
+


### PR DESCRIPTION
## Summary
- raise the Android compileSdk level to 36 to satisfy updated plugin requirements
- update the Kotlin Gradle plugin to 2.1.0 to stay within supported Flutter tooling
- normalize the iOS secure storage accessibility option to handle multiple enum names

## Testing
- not run (Flutter/Dart SDK unavailable in container)

------
https://chatgpt.com/codex/tasks/task_e_690206c530e0832da2e5a8157e8abb2a