### PR TITLE
Clean unused dependencies and fix secure storage enum

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -127,5 +127,10 @@ echo "✅ Setup completed for $APP_NAME"
    - Follow authentication and authorization best practices
    - Keep dependencies updated
 
+8. **PUBSPEC DEPENDENCY STYLE**: When adding new dependencies to `pubspec.yaml`,
+   list only the package name followed by a colon (no explicit version
+   constraints). This keeps the project aligned with the team's dependency
+   management approach.
+
 **Remember**: The goal is to maintain a high-quality, production-ready codebase that is well-documented and thoroughly tested.
 ```

--- a/lib/component/onboarding_screens/onboarding_screen.dart
+++ b/lib/component/onboarding_screens/onboarding_screen.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
-import 'package:flutter_secure_storage_platform_interface/flutter_secure_storage_platform_interface.dart'
-    show IOSAccessibility;
 import 'package:shared_preferences/shared_preferences.dart';
 
 import '../../pages/auth/auth_flow_screen.dart';
@@ -630,12 +628,12 @@ class _QuickLink extends StatelessWidget {
     );
   }
 }
-final IOSAccessibility _firstUnlockThisDeviceOnlyAccessibility =
+final KeychainAccessibility _firstUnlockThisDeviceOnlyAccessibility =
     _resolveFirstUnlockThisDeviceOnly();
 
-IOSAccessibility _resolveFirstUnlockThisDeviceOnly() {
-  IOSAccessibility? matched;
-  for (final option in IOSAccessibility.values) {
+KeychainAccessibility _resolveFirstUnlockThisDeviceOnly() {
+  KeychainAccessibility? matched;
+  for (final option in KeychainAccessibility.values) {
     switch (option.name) {
       case 'first_unlock_this_device_only':
       case 'first_unlockThisDeviceOnly':
@@ -651,6 +649,6 @@ IOSAccessibility _resolveFirstUnlockThisDeviceOnly() {
         break;
     }
   }
-  return matched ?? IOSAccessibility.values.first;
+  return matched ?? KeychainAccessibility.values.first;
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,30 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  cached_network_image:
-    dependency: "direct main"
-    description:
-      name: cached_network_image
-      sha256: "7c1183e361e5c8b0a0f21a28401eecdbde252441106a9816400dd4c2b2424916"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.4.1"
-  cached_network_image_platform_interface:
-    dependency: transitive
-    description:
-      name: cached_network_image_platform_interface
-      sha256: "35814b016e37fbdc91f7ae18c8caf49ba5c88501813f73ce8a07027a395e2829"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.1.1"
-  cached_network_image_web:
-    dependency: transitive
-    description:
-      name: cached_network_image_web
-      sha256: "980842f4e8e2535b8dbd3d5ca0b1f0ba66bf61d14cc3a17a9b4788a3685ba062"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.3.1"
   characters:
     dependency: transitive
     description:
@@ -113,14 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
-  collection:
-    dependency: "direct main"
-    description:
-      name: collection
-      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.19.1"
   connectivity_plus:
     dependency: "direct main"
     description:
@@ -201,14 +169,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.3"
-  faker:
-    dependency: "direct main"
-    description:
-      name: faker
-      sha256: "544c34e9e1d322824156d5a8d451bc1bb778263b892aded24ec7ba77b0706624"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.0"
   fetch_api:
     dependency: transitive
     description:
@@ -289,35 +249,11 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  fl_chart:
-    dependency: "direct main"
-    description:
-      name: fl_chart
-      sha256: "5a74434cc83bf64346efb562f1a06eefaf1bcb530dc3d96a104f631a1eff8d79"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.65.0"
-  flare_flutter:
-    dependency: "direct main"
-    description:
-      name: flare_flutter
-      sha256: "99d63c60f00fac81249ce6410ee015d7b125c63d8278a30da81edf3317a1f6a0"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.0.2"
   flutter:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_bloc:
-    dependency: "direct main"
-    description:
-      name: flutter_bloc
-      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.1.6"
   flutter_cache_manager:
     dependency: transitive
     description:
@@ -383,7 +319,7 @@ packages:
     source: hosted
     version: "3.1.3"
   flutter_secure_storage_platform_interface:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: flutter_secure_storage_platform_interface
       sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
@@ -592,14 +528,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
-  lottie:
-    dependency: "direct main"
-    description:
-      name: lottie
-      sha256: a93542cc2d60a7057255405f62252533f8e8956e7e06754955669fd32fb4b216
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.7.0"
   markdown:
     dependency: transitive
     description:
@@ -664,14 +592,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
-  ollama_dart:
-    dependency: "direct main"
-    description:
-      name: ollama_dart
-      sha256: "0af52c17a6dda9f6a30d79b9529bf38128d9b01dabd9d5f625040a32035eec24"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.0.3+1"
   path:
     dependency: "direct main"
     description:
@@ -688,54 +608,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.0"
-  path_provider:
-    dependency: "direct main"
-    description:
-      name: path_provider
-      sha256: "50c5dd5b6e1aaf6fb3a78b33f6aa3afca52bf903a8a5298f53101fdaee55bbcd"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.5"
-  path_provider_android:
-    dependency: transitive
-    description:
-      name: path_provider_android
-      sha256: "0ca7359dad67fd7063cb2892ab0c0737b2daafd807cf1acecd62374c8fae6c12"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.16"
-  path_provider_foundation:
-    dependency: transitive
-    description:
-      name: path_provider_foundation
-      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.1"
-  path_provider_linux:
-    dependency: transitive
-    description:
-      name: path_provider_linux
-      sha256: f7a1fe3a634fe7734c8d3f2766ad746ae2a2884abe22e241a8b301bf5cac3279
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.1"
-  path_provider_platform_interface:
-    dependency: transitive
-    description:
-      name: path_provider_platform_interface
-      sha256: "88f5779f72ba699763fa3a3b06aa4bf6de76c8e5de842cf6f29e2e06476c2334"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.1.2"
-  path_provider_windows:
-    dependency: transitive
-    description:
-      name: path_provider_windows
-      sha256: bd6f00dbd873bfb70d0761682da2b3a2c2fccc2b9e84c495821639601d81afe7
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.0"
   permission_handler:
     dependency: "direct main"
     description:
@@ -909,14 +781,6 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  smooth_page_indicator:
-    dependency: "direct main"
-    description:
-      name: smooth_page_indicator
-      sha256: b21ebb8bc39cf72d11c7cfd809162a48c3800668ced1c9da3aade13a32cf6c1c
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.1"
   source_span:
     dependency: transitive
     description:
@@ -933,70 +797,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.0"
-  sqflite:
-    dependency: "direct main"
-    description:
-      name: sqflite
-      sha256: e2297b1da52f127bc7a3da11439985d9b536f75070f3325e62ada69a5c585d03
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
-  sqflite_android:
-    dependency: transitive
-    description:
-      name: sqflite_android
-      sha256: "2b3070c5fa881839f8b402ee4a39c1b4d561704d4ebbbcfb808a119bc2a1701b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.1"
-  sqflite_common:
-    dependency: transitive
-    description:
-      name: sqflite_common
-      sha256: "84731e8bfd8303a3389903e01fb2141b6e59b5973cacbb0929021df08dddbe8b"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.5.5"
-  sqflite_common_ffi:
-    dependency: "direct main"
-    description:
-      name: sqflite_common_ffi
-      sha256: "1f3ef3888d3bfbb47785cc1dda0dc7dd7ebd8c1955d32a9e8e9dae1e38d1c4c1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.3.5"
-  sqflite_darwin:
-    dependency: transitive
-    description:
-      name: sqflite_darwin
-      sha256: "279832e5cde3fe99e8571879498c9211f3ca6391b0d818df4e17d9fff5c6ccb3"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.2"
-  sqflite_platform_interface:
-    dependency: transitive
-    description:
-      name: sqflite_platform_interface
-      sha256: "8dd4515c7bdcae0a785b0062859336de775e8c65db81ae33dd5445f35be61920"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.4.0"
-  sqlite3:
-    dependency: transitive
-    description:
-      name: sqlite3
-      sha256: "310af39c40dd0bb2058538333c9d9840a2725ae0b9f77e4fd09ad6696aa8f66e"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.7.5"
-  sqlite3_flutter_libs:
-    dependency: "direct main"
-    description:
-      name: sqlite3_flutter_libs
-      sha256: "1a96b59227828d9eb1463191d684b37a27d66ee5ed7597fcf42eee6452c88a14"
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.5.32"
   stack_trace:
     dependency: transitive
     description:
@@ -1053,14 +853,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
-  timeago:
-    dependency: "direct main"
-    description:
-      name: timeago
-      sha256: "054cedf68706bb142839ba0ae6b135f6b68039f0b8301cbe8784ae653d5ff8de"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.7.0"
   typed_data:
     dependency: transitive
     description:
@@ -1189,38 +981,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
-  webview_flutter:
-    dependency: "direct main"
-    description:
-      name: webview_flutter
-      sha256: "889a0a678e7c793c308c68739996227c9661590605e70b1f6cf6b9a6634f7aec"
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.10.0"
-  webview_flutter_android:
-    dependency: transitive
-    description:
-      name: webview_flutter_android
-      sha256: e09150b28a07933839adef0e4a088bb43e8c8d9e6b93025b01882d4067a58ab0
-      url: "https://pub.dev"
-    source: hosted
-    version: "4.3.4"
-  webview_flutter_platform_interface:
-    dependency: transitive
-    description:
-      name: webview_flutter_platform_interface
-      sha256: d937581d6e558908d7ae3dc1989c4f87b786891ab47bb9df7de548a151779d8d
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.10.0"
-  webview_flutter_wkwebview:
-    dependency: transitive
-    description:
-      name: webview_flutter_wkwebview
-      sha256: c14455137ce60a68e1ccaf4e8f2dae8cebcb3465ddaa2fcfb57584fb7c5afe4d
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.18.5"
   win32:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,24 +21,16 @@ dependencies:
     sdk: flutter
   flutter_svg: ^2.0.7
   image_picker: ^1.0.4
-  flare_flutter: ^3.0.0
   http: ^1.1.0
   animated_text_kit: ^4.2.3
   shared_preferences: ^2.2.2
   flutter_markdown: ^0.6.18
-  lottie: ^2.7.0
-  smooth_page_indicator: ^1.1.0
   clipboard: ^0.1.3
   device_info_plus: ^9.0.2
-  path_provider: ^2.1.1
   system_info2: ^4.0.0
   url_launcher: ^6.2.4
   permission_handler: ^11.0.1
   flutter_secure_storage: ^9.0.0
-  flutter_secure_storage_platform_interface: ^1.1.2
-  timeago: ^3.6.0
-  ollama_dart: ^0.0.2
-  flutter_bloc: ^8.1.4
   equatable: ^2.0.5
   sign_in_with_apple: ^6.1.4
   # The following adds the Cupertino Icons font to your application.
@@ -47,18 +39,10 @@ dependencies:
   flutter_launcher_icons: ^0.14.3
   uuid: ^4.5.1
   file_picker: ^9.0.2
-  sqflite: ^2.3.2
   path: ^1.8.3
   provider: ^6.0.5
   google_fonts: ^6.1.0
-  faker: ^2.1.0
-  collection: ^1.18.0
   intl: ^0.18.1
-  sqflite_common_ffi: ^2.3.0+2
-  sqlite3_flutter_libs: ^0.5.18
-  webview_flutter: ^4.4.2
-  fl_chart: ^0.65.0
-  cached_network_image: ^3.3.0
   connectivity_plus: ^6.0.5
   crypto: ^3.0.3
 


### PR DESCRIPTION
## Summary
- replace the deprecated IOSAccessibility usage in the onboarding flow with KeychainAccessibility
- remove unused storage- and UI-related dependencies from pubspec.yaml and synchronize pubspec.lock
- document the dependency versioning convention in AGENTS.md

## Testing
- not run (Flutter SDK not available in container)


------
https://chatgpt.com/codex/tasks/task_e_69020ad20fe0832dbe20ffb52516f997