### PR TITLE
Handle legacy models filter syntax

### DIFF
--- a/pocketllm-backend/app/api/v1/endpoints/models.py
+++ b/pocketllm-backend/app/api/v1/endpoints/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from urllib.parse import parse_qs
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -34,13 +35,41 @@ async def list_models(
     model_id: str | None = Query(default=None, description="Case-insensitive substring filter applied to model identifiers"),
     query: str | None = Query(default=None, description="Free text search across model id, name, and description"),
 ) -> ProviderModelsResponse:
-    service = ProvidersService(settings=settings, database=database)
-    return await service.get_provider_models(
-        user.sub,
+    return await _resolve_models_response(
+        user,
+        settings,
+        database,
         provider=provider,
         name=name,
         model_id=model_id,
         query=query,
+    )
+
+
+@router.get(
+    "&&{filters:path}",
+    response_model=ProviderModelsResponse,
+    include_in_schema=False,
+    summary="List provider models (legacy filter syntax)",
+)
+async def list_models_with_legacy_filters(
+    filters: str,
+    user: TokenPayload = Depends(get_current_request_user),
+    settings=Depends(get_settings_dependency),
+    database=Depends(get_database_dependency),
+) -> ProviderModelsResponse:
+    """Support clients that append filters using ``&&`` instead of ``?``."""
+
+    parsed_filters = parse_qs(filters, keep_blank_values=False)
+
+    return await _resolve_models_response(
+        user,
+        settings,
+        database,
+        provider=_first_query_value(parsed_filters, "provider"),
+        name=_first_query_value(parsed_filters, "name"),
+        model_id=_first_query_value(parsed_filters, "model_id"),
+        query=_first_query_value(parsed_filters, "query"),
     )
 
 
@@ -81,6 +110,39 @@ async def delete_model(
 ) -> None:
     service = ModelsService(database=database)
     await service.delete_model(user.sub, model_id)
+
+
+async def _resolve_models_response(
+    user: TokenPayload,
+    settings,
+    database,
+    *,
+    provider: str | None = None,
+    name: str | None = None,
+    model_id: str | None = None,
+    query: str | None = None,
+) -> ProviderModelsResponse:
+    service = ProvidersService(settings=settings, database=database)
+    return await service.get_provider_models(
+        user.sub,
+        provider=provider,
+        name=name,
+        model_id=model_id,
+        query=query,
+    )
+
+
+def _first_query_value(parameters: dict[str, list[str]], key: str) -> str | None:
+    """Return the first non-empty value for ``key`` from parsed query parameters."""
+
+    values = parameters.get(key)
+    if not values:
+        return None
+    for value in values:
+        candidate = value.strip()
+        if candidate:
+            return candidate
+    return None
 
 
 @router.post("/{model_id}/default", response_model=ModelConfiguration, summary="Set default model")

--- a/pocketllm-backend/app/services/providers/imagerouter.py
+++ b/pocketllm-backend/app/services/providers/imagerouter.py
@@ -19,6 +19,7 @@ class ImageRouterProviderClient(ProviderClient):
     provider = "imagerouter"
     default_base_url = "https://api.imagerouter.io"
     models_endpoint = "/v1/models"
+    requires_api_key = False
 
     def __init__(
         self,
@@ -42,7 +43,20 @@ class ImageRouterProviderClient(ProviderClient):
     def base_url(self) -> str:
         if self._base_url_override:
             return self._base_url_override
+        api_base = getattr(self._settings, "imagerouter_api_base", None)
+        if isinstance(api_base, str) and api_base.strip():
+            return api_base.strip()
         return self.default_base_url
+
+    def _get_api_key(self) -> str | None:
+        if self._api_key_override:
+            return self._api_key_override
+        api_key = getattr(self._settings, "imagerouter_api_key", None)
+        if isinstance(api_key, str):
+            api_key = api_key.strip()
+            if api_key:
+                return api_key
+        return None
 
     async def list_models(self) -> list[ProviderModel]:
         """Fetch available image generation models from ImageRouter."""

--- a/pocketllm-backend/tests/test_models_filters.py
+++ b/pocketllm-backend/tests/test_models_filters.py
@@ -1,0 +1,123 @@
+"""Ensure the models endpoint supports legacy filter syntax."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.deps import (
+    get_current_request_user,
+    get_database_dependency,
+    get_settings_dependency,
+)
+from app.schemas.auth import TokenPayload
+from app.schemas.providers import ProviderModel, ProviderModelsResponse
+
+
+def _load_app():
+    project_root = Path(__file__).resolve().parents[1]
+    module_path = project_root / "main.py"
+    os.environ.setdefault("ENVIRONMENT", "test")
+    spec = importlib.util.spec_from_file_location("pocketllm_backend.main", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load FastAPI application")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    import app.api.v1.endpoints.models as models_endpoint
+
+    app = _load_app()
+    calls: list[dict[str, Any]] = []
+
+    class StubProvidersService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            pass
+
+        async def get_provider_models(
+            self,
+            user_id,
+            *,
+            provider: str | None = None,
+            name: str | None = None,
+            model_id: str | None = None,
+            query: str | None = None,
+        ) -> ProviderModelsResponse:
+            calls.append(
+                {
+                    "user_id": user_id,
+                    "provider": provider,
+                    "name": name,
+                    "model_id": model_id,
+                    "query": query,
+                }
+            )
+            return ProviderModelsResponse(
+                models=[
+                    ProviderModel(
+                        provider="imagerouter",
+                        id="imagerouter-test",
+                        name="ImageRouter Test",
+                    )
+                ],
+                configured_providers=["imagerouter"],
+            )
+
+    monkeypatch.setattr(models_endpoint, "ProvidersService", StubProvidersService)
+
+    async def override_current_user():
+        return TokenPayload(
+            sub=uuid4(),
+            exp=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+
+    async def override_settings():
+        return SimpleNamespace()
+
+    async def override_database():
+        return SimpleNamespace()
+
+    app.dependency_overrides[get_current_request_user] = override_current_user
+    app.dependency_overrides[get_settings_dependency] = override_settings
+    app.dependency_overrides[get_database_dependency] = override_database
+
+    test_client = TestClient(app)
+    try:
+        yield test_client, calls
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_models_endpoint_supports_legacy_filter_path(client):
+    test_client, calls = client
+    response = test_client.get("/v1/models&&provider=imagerouter")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["models"][0]["provider"] == "imagerouter"
+    assert calls
+    assert calls[-1]["provider"] == "imagerouter"
+
+
+def test_legacy_filter_path_parses_optional_filters(client):
+    test_client, calls = client
+    response = test_client.get(
+        "/v1/models&&provider=imagerouter&name=flux&model_id=flux-pro&query=flux"
+    )
+    assert response.status_code == 200
+    assert calls
+    last_call = calls[-1]
+    assert last_call["provider"] == "imagerouter"
+    assert last_call["name"] == "flux"
+    assert last_call["model_id"] == "flux-pro"
+    assert last_call["query"] == "flux"

--- a/pocketllm-backend/tests/test_provider_catalogue.py
+++ b/pocketllm-backend/tests/test_provider_catalogue.py
@@ -199,9 +199,17 @@ def make_provider_record(
     )
 
 class FakeCatalogue:
-    def __init__(self, models: list[ProviderModel]) -> None:
+    def __init__(
+        self,
+        models: list[ProviderModel],
+        *,
+        requires: Mapping[str, bool] | None = None,
+    ) -> None:
         self._models = list(models)
         self.calls: list[tuple[str, Any]] = []
+        self._requires = {
+            key.lower(): bool(value) for key, value in (requires or {}).items()
+        }
 
     async def list_all_models(self, providers: Any = None) -> list[ProviderModel]:
         self.calls.append(("all", providers))
@@ -211,6 +219,9 @@ class FakeCatalogue:
         self.calls.append((provider, providers))
         provider_key = provider.lower()
         return [model for model in self._models if model.provider.lower() == provider_key]
+
+    def provider_requires_api_key(self, provider: str) -> bool:
+        return self._requires.get(provider.lower(), True)
 
 
 def test_normalise_skips_environment_fallback_for_user_configured_provider() -> None:
@@ -405,6 +416,51 @@ async def test_catalogue_handles_provider_errors(caplog):
 
     assert models == []
     assert any("openrouter" in message for message in caplog.text.splitlines())
+
+
+@pytest.mark.asyncio
+async def test_catalogue_uses_imagerouter_fallback_without_api_key():
+    class TrackingImageRouterClient(ImageRouterProviderClient):
+        created: list[dict[str, Any]] = []
+
+        def __init__(
+            self,
+            settings: Settings,
+            *,
+            base_url: str | None = None,
+            api_key: str | None = None,
+            metadata: Mapping[str, Any] | None = None,
+            transport: Any | None = None,
+        ) -> None:
+            type(self).created.append(
+                {
+                    "base_url": base_url,
+                    "api_key": api_key,
+                    "metadata": dict(metadata or {}),
+                }
+            )
+            super().__init__(
+                settings,
+                base_url=base_url,
+                api_key=api_key,
+                metadata=metadata,
+                transport=transport,
+            )
+
+        async def list_models(self) -> list[ProviderModel]:  # pragma: no cover - not exercised
+            return []
+
+    settings = make_settings()
+    TrackingImageRouterClient.created.clear()
+    catalogue = ProviderModelCatalogue(
+        settings,
+        client_factories={"imagerouter": TrackingImageRouterClient},
+    )
+
+    clients = catalogue._get_clients(None)
+
+    assert [client.provider for client in clients] == ["imagerouter"]
+    assert TrackingImageRouterClient.created[-1]["api_key"] is None
 
 
 @pytest.mark.asyncio
@@ -912,6 +968,33 @@ async def test_imagerouter_provider_client_fetches_models_via_http():
 
 
 @pytest.mark.asyncio
+async def test_imagerouter_provider_client_lists_models_without_api_key():
+    payload = {
+        "data": [
+            {
+                "id": "imagerouter/image-public",
+                "name": "Image Public",
+            }
+        ]
+    }
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    settings = make_settings()
+    client = ImageRouterProviderClient(settings, transport=transport)
+
+    models = await client.list_models()
+
+    assert [model.id for model in models] == ["imagerouter/image-public"]
+    assert captured and "authorization" not in captured[0].headers
+
+
+@pytest.mark.asyncio
 async def test_imagerouter_provider_client_handles_models_key():
     payload = {
         "models": [
@@ -1003,6 +1086,64 @@ async def test_providers_service_respects_provider_parameter():
     assert [model.provider for model in groq_models.models] == ["groq"]
     assert catalogue.calls and catalogue.calls[0][0] == "groq"
 
+
+@pytest.mark.asyncio
+async def test_providers_service_exposes_public_imagerouter_catalogue_without_configuration():
+    models = [
+        ProviderModel(provider="imagerouter", id="imagerouter/public", name="Public"),
+    ]
+    catalogue = FakeCatalogue(models, requires={"imagerouter": False})
+    settings = make_settings()
+    service = ProvidersService(settings, database=FakeDatabase(), catalogue=catalogue)
+    user_id = uuid4()
+
+    async def stub_fetch(_: UUID) -> list[ProviderRecord]:
+        return []
+
+    service._fetch_provider_records = stub_fetch  # type: ignore[assignment]
+
+    response = await service.get_provider_models(user_id, provider="imagerouter")
+
+    assert [model.id for model in response.models] == ["imagerouter/public"]
+    assert response.using_fallback is True
+    assert response.message and "public catalogue" in response.message.lower()
+    assert catalogue.calls and catalogue.calls[0][0] == "imagerouter"
+
+
+@pytest.mark.asyncio
+async def test_providers_service_accepts_optional_provider_without_api_key():
+    model = ProviderModel(provider="imagerouter", id="imagerouter/live", name="Live")
+    catalogue = FakeCatalogue([model], requires={"imagerouter": False})
+    settings = make_settings()
+    service = ProvidersService(settings, database=FakeDatabase(), catalogue=catalogue)
+    user_id = uuid4()
+    now = datetime.now(tz=UTC)
+
+    provider_record = ProviderRecord(
+        id=uuid4(),
+        user_id=user_id,
+        provider="imagerouter",
+        display_name=None,
+        base_url=None,
+        metadata=None,
+        api_key_hash=None,
+        api_key_preview=None,
+        api_key_encrypted=None,
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+        api_key=None,
+    )
+
+    async def stub_fetch(_: UUID) -> list[ProviderRecord]:
+        return [provider_record]
+
+    service._fetch_provider_records = stub_fetch  # type: ignore[assignment]
+
+    response = await service.get_provider_models(user_id, provider="imagerouter")
+
+    assert [returned.id for returned in response.models] == ["imagerouter/live"]
+    assert catalogue.calls and catalogue.calls[0][1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- accept legacy `/v1/models&&...` requests by parsing filter parameters before delegating to the provider service
- reuse a shared helper so both model listing routes resolve provider filters consistently
- cover the legacy path handling with FastAPI tests to ensure ImageRouter catalogues remain accessible

## Testing
- pytest pocketllm-backend/tests/test_models_filters.py

------
https://chatgpt.com/codex/tasks/task_e_6902003634a4832db9d89b3f1e9eb1d7