### PR TITLE
Expand ImageRouter model catalogue parsing

### DIFF
--- a/pocketllm-backend/app/api/v1/endpoints/models.py
+++ b/pocketllm-backend/app/api/v1/endpoints/models.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from urllib.parse import parse_qs
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Query
@@ -34,13 +35,41 @@ async def list_models(
     model_id: str | None = Query(default=None, description="Case-insensitive substring filter applied to model identifiers"),
     query: str | None = Query(default=None, description="Free text search across model id, name, and description"),
 ) -> ProviderModelsResponse:
-    service = ProvidersService(settings=settings, database=database)
-    return await service.get_provider_models(
-        user.sub,
+    return await _resolve_models_response(
+        user,
+        settings,
+        database,
         provider=provider,
         name=name,
         model_id=model_id,
         query=query,
+    )
+
+
+@router.get(
+    "&&{filters:path}",
+    response_model=ProviderModelsResponse,
+    include_in_schema=False,
+    summary="List provider models (legacy filter syntax)",
+)
+async def list_models_with_legacy_filters(
+    filters: str,
+    user: TokenPayload = Depends(get_current_request_user),
+    settings=Depends(get_settings_dependency),
+    database=Depends(get_database_dependency),
+) -> ProviderModelsResponse:
+    """Support clients that append filters using ``&&`` instead of ``?``."""
+
+    parsed_filters = parse_qs(filters, keep_blank_values=False)
+
+    return await _resolve_models_response(
+        user,
+        settings,
+        database,
+        provider=_first_query_value(parsed_filters, "provider"),
+        name=_first_query_value(parsed_filters, "name"),
+        model_id=_first_query_value(parsed_filters, "model_id"),
+        query=_first_query_value(parsed_filters, "query"),
     )
 
 
@@ -81,6 +110,39 @@ async def delete_model(
 ) -> None:
     service = ModelsService(database=database)
     await service.delete_model(user.sub, model_id)
+
+
+async def _resolve_models_response(
+    user: TokenPayload,
+    settings,
+    database,
+    *,
+    provider: str | None = None,
+    name: str | None = None,
+    model_id: str | None = None,
+    query: str | None = None,
+) -> ProviderModelsResponse:
+    service = ProvidersService(settings=settings, database=database)
+    return await service.get_provider_models(
+        user.sub,
+        provider=provider,
+        name=name,
+        model_id=model_id,
+        query=query,
+    )
+
+
+def _first_query_value(parameters: dict[str, list[str]], key: str) -> str | None:
+    """Return the first non-empty value for ``key`` from parsed query parameters."""
+
+    values = parameters.get(key)
+    if not values:
+        return None
+    for value in values:
+        candidate = value.strip()
+        if candidate:
+            return candidate
+    return None
 
 
 @router.post("/{model_id}/default", response_model=ModelConfiguration, summary="Set default model")

--- a/pocketllm-backend/app/services/providers/imagerouter.py
+++ b/pocketllm-backend/app/services/providers/imagerouter.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections import deque
 from typing import Any, Mapping
 
 import httpx
@@ -19,6 +20,7 @@ class ImageRouterProviderClient(ProviderClient):
     provider = "imagerouter"
     default_base_url = "https://api.imagerouter.io"
     models_endpoint = "/v1/models"
+    requires_api_key = False
 
     def __init__(
         self,
@@ -42,7 +44,20 @@ class ImageRouterProviderClient(ProviderClient):
     def base_url(self) -> str:
         if self._base_url_override:
             return self._base_url_override
+        api_base = getattr(self._settings, "imagerouter_api_base", None)
+        if isinstance(api_base, str) and api_base.strip():
+            return api_base.strip()
         return self.default_base_url
+
+    def _get_api_key(self) -> str | None:
+        if self._api_key_override:
+            return self._api_key_override
+        api_key = getattr(self._settings, "imagerouter_api_key", None)
+        if isinstance(api_key, str):
+            api_key = api_key.strip()
+            if api_key:
+                return api_key
+        return None
 
     async def list_models(self) -> list[ProviderModel]:
         """Fetch available image generation models from ImageRouter."""
@@ -64,7 +79,13 @@ class ImageRouterProviderClient(ProviderClient):
             ) as client:
                 response = await client.get(self.models_endpoint)
                 response.raise_for_status()
-                return self._parse_models(response.json())
+                payload = response.json()
+                models = self._parse_models(payload)
+                if models:
+                    self._logger.debug(
+                        "Fetched %d models from %s", len(models), self.provider
+                    )
+                return models
 
         except httpx.HTTPStatusError as exc:
             self._logger.error(
@@ -77,7 +98,9 @@ class ImageRouterProviderClient(ProviderClient):
             self._logger.error("ImageRouter HTTP request failed: %s", exc)
             return []
         except Exception:
-            self._logger.exception("Unexpected error while fetching models from %s", self.provider)
+            self._logger.exception(
+                "Unexpected error while fetching models from %s", self.provider
+            )
             return []
 
     def _build_headers(self, api_key: str | None) -> dict[str, str]:
@@ -102,13 +125,21 @@ class ImageRouterProviderClient(ProviderClient):
         models: list[ProviderModel] = []
 
         try:
+            if isinstance(payload, Mapping):
+                mapped_models = self._parse_models_from_mapping(payload)
+                if mapped_models:
+                    models.extend(mapped_models)
+                    return models
+
             model_list = self._extract_model_list(payload)
             if model_list is None:
                 self._logger.warning(
-                    "Unexpected ImageRouter models response format: %s", type(payload)
+                    "Unexpected ImageRouter models response format: %s",
+                    self._summarise_payload(payload),
                 )
                 return models
 
+            raw_entries = len(model_list)
             for model_data in model_list:
                 try:
                     if hasattr(model_data, "model_dump"):
@@ -121,44 +152,10 @@ class ImageRouterProviderClient(ProviderClient):
                         )
                         continue
 
-                    model_id = str(model_mapping.get("id", "")).strip()
-                    if not model_id:
+                    parsed = self._build_model_from_mapping(model_mapping)
+                    if parsed is None:
                         continue
-
-                    name = model_mapping.get("name") or model_id.replace("_", " ").title()
-
-                    metadata: dict[str, Any] = {}
-                    capabilities = model_mapping.get("capabilities")
-                    if isinstance(capabilities, list) and capabilities:
-                        metadata["capabilities"] = capabilities
-                    else:
-                        metadata["capabilities"] = ["image_generation"]
-
-                    for key in ("supported_formats", "quality_levels", "size_options"):
-                        value = model_mapping.get(key)
-                        if value:
-                            metadata[key] = value
-
-                    for key in ("created", "owned_by", "provider"):
-                        value = model_mapping.get(key)
-                        if value not in (None, ""):
-                            metadata[key] = value
-
-                    models.append(
-                        ProviderModel(
-                            provider=self.provider,
-                            id=model_id,
-                            name=name,
-                            description=model_mapping.get(
-                                "description", f"Image generation model: {name}"
-                            ),
-                            context_window=None,
-                            max_output_tokens=None,
-                            pricing=model_mapping.get("pricing"),
-                            is_active=True,
-                            metadata=metadata or None,
-                        )
-                    )
+                    models.append(parsed)
 
                 except Exception as exc:
                     self._logger.warning(
@@ -169,29 +166,331 @@ class ImageRouterProviderClient(ProviderClient):
 
         except Exception as exc:
             self._logger.error("Failed to parse ImageRouter models response: %s", exc)
+        else:
+            if not models:
+                self._logger.warning(
+                    "ImageRouter response contained %d entries but none were usable; payload summary=%s",
+                    raw_entries,
+                    self._summarise_payload(payload),
+                )
 
         return models
+
+    def _parse_models_from_mapping(self, payload: Mapping[str, Any]) -> list[ProviderModel]:
+        """Extract models when ImageRouter returns a mapping keyed by model slug."""
+
+        catalogue_candidates: deque[Mapping[str, Any]] = deque([payload])
+        seen: set[int] = set()
+        results: list[ProviderModel] = []
+
+        while catalogue_candidates:
+            current = catalogue_candidates.popleft()
+            current_id = id(current)
+            if current_id in seen:
+                continue
+            seen.add(current_id)
+
+            model_entries = self._normalise_catalogue_mapping(current)
+            if model_entries:
+                results.extend(model_entries)
+                continue
+
+            for value in current.values():
+                if isinstance(value, Mapping):
+                    catalogue_candidates.append(value)
+
+        return results
+
+    def _normalise_catalogue_mapping(
+        self, mapping: Mapping[str, Any]
+    ) -> list[ProviderModel]:
+        """Convert a mapping of ImageRouter models into ProviderModel entries."""
+
+        models: list[ProviderModel] = []
+        for slug, data in mapping.items():
+            if not isinstance(slug, str) or not isinstance(data, Mapping):
+                continue
+
+            providers = data.get("providers")
+            if not isinstance(providers, list) or not providers:
+                continue
+
+            base_metadata = self._build_common_metadata(slug, data)
+            base_name = data.get("name") or self._format_model_name(slug)
+            description = data.get(
+                "description",
+                f"ImageRouter model '{slug}'",
+            )
+
+            for provider_entry in providers:
+                if not isinstance(provider_entry, Mapping):
+                    continue
+
+                provider_id = str(provider_entry.get("id", "")).strip()
+                provider_model_name = provider_entry.get("model_name")
+                pricing = provider_entry.get("pricing")
+
+                model_id = self._compose_model_id(slug, provider_id, provider_model_name)
+                metadata = self._attach_provider_metadata(
+                    base_metadata,
+                    provider_id,
+                    provider_model_name,
+                    pricing,
+                )
+
+                models.append(
+                    ProviderModel(
+                        provider=self.provider,
+                        id=model_id,
+                        name=self._format_provider_name(base_name, provider_id),
+                        description=description,
+                        context_window=None,
+                        max_output_tokens=None,
+                        pricing=pricing,
+                        is_active=True,
+                        metadata=metadata,
+                    )
+                )
+
+        return models
+
+    def _build_model_from_mapping(self, model_mapping: Mapping[str, Any]) -> ProviderModel | None:
+        model_id = str(model_mapping.get("id", "")).strip()
+        if not model_id:
+            return None
+
+        name = model_mapping.get("name") or model_id.replace("_", " ").title()
+
+        metadata: dict[str, Any] = {}
+        capabilities = model_mapping.get("capabilities")
+        if isinstance(capabilities, list) and capabilities:
+            metadata["capabilities"] = capabilities
+        else:
+            metadata["capabilities"] = ["image_generation"]
+
+        for key in ("supported_formats", "quality_levels", "size_options"):
+            value = model_mapping.get(key)
+            if value:
+                metadata[key] = value
+
+        for key in ("created", "owned_by", "provider"):
+            value = model_mapping.get(key)
+            if value not in (None, ""):
+                metadata[key] = value
+
+        return ProviderModel(
+            provider=self.provider,
+            id=model_id,
+            name=name,
+            description=model_mapping.get(
+                "description", f"Image generation model: {name}"
+            ),
+            context_window=None,
+            max_output_tokens=None,
+            pricing=model_mapping.get("pricing"),
+            is_active=True,
+            metadata=metadata or None,
+        )
 
     def _extract_model_list(self, payload: Any) -> list[Any] | None:
         """Normalise the ImageRouter response payload into a list of model entries."""
 
-        if isinstance(payload, Mapping):
-            for key in ("data", "models"):
-                candidate = payload.get(key)
-                if isinstance(candidate, list):
-                    return candidate
-            if "data" in payload and hasattr(payload["data"], "values"):
-                candidate = payload["data"]
-                if isinstance(candidate, list):
-                    return candidate
-        elif hasattr(payload, "data"):
-            data = getattr(payload, "data")
-            if isinstance(data, list):
-                return data
-        elif isinstance(payload, list):
+        for extractor in (
+            self._extract_from_mapping,
+            self._extract_from_attribute,
+        ):
+            models = extractor(payload)
+            if models is not None:
+                return models
+        if isinstance(payload, list) and any(self._is_model_entry(item) for item in payload):
             return payload
 
         return None
+
+    def _extract_from_mapping(self, payload: Any) -> list[Any] | None:
+        if not isinstance(payload, Mapping):
+            return None
+
+        search_queue: deque[Any] = deque([payload])
+        seen: set[int] = set()
+
+        while search_queue:
+            current = search_queue.popleft()
+            current_id = id(current)
+            if current_id in seen:
+                continue
+            seen.add(current_id)
+
+            if isinstance(current, list):
+                if any(self._is_model_entry(item) for item in current):
+                    return current
+                continue
+
+            if not isinstance(current, Mapping):
+                continue
+
+            for key in ("models", "data", "items", "results", "entries", "list"):
+                if key not in current:
+                    continue
+                candidate = current[key]
+                if isinstance(candidate, list) and any(
+                    self._is_model_entry(item) for item in candidate
+                ):
+                    return candidate
+                if isinstance(candidate, (Mapping, list)):
+                    search_queue.append(candidate)
+
+            for value in current.values():
+                if isinstance(value, list) and any(
+                    self._is_model_entry(item) for item in value
+                ):
+                    return value
+                if isinstance(value, (Mapping, list)):
+                    search_queue.append(value)
+
+        return None
+
+    def _extract_from_attribute(self, payload: Any) -> list[Any] | None:
+        for attr in ("data", "models", "items", "results"):
+            if hasattr(payload, attr):
+                value = getattr(payload, attr)
+                if isinstance(value, list) and any(
+                    self._is_model_entry(item) for item in value
+                ):
+                    return value
+                if isinstance(value, Mapping):
+                    nested = self._extract_from_mapping(value)
+                    if nested is not None:
+                        return nested
+        return None
+
+    def _is_model_entry(self, value: Any) -> bool:
+        return isinstance(value, Mapping) or hasattr(value, "model_dump")
+
+    def _summarise_payload(self, payload: Any) -> str:
+        try:
+            if isinstance(payload, Mapping):
+                keys = list(payload.keys())
+                sample_types = {
+                    key: type(payload[key]).__name__ for key in keys[:5]
+                }
+                nested_keys: dict[str, list[str]] = {}
+                for key in keys[:3]:
+                    nested_value = payload[key]
+                    if isinstance(nested_value, Mapping):
+                        nested_keys[key] = list(nested_value.keys())[:5]
+                parts = [f"keys={keys[:5]}", f"types={sample_types}"]
+                if nested_keys:
+                    parts.append(f"nested_keys={nested_keys}")
+                summary = ", ".join(parts)
+                return f"mapping({summary})"
+            if isinstance(payload, list):
+                item_types = [type(item).__name__ for item in payload[:5]]
+                return f"list(len={len(payload)}, item_types={item_types})"
+            return repr(payload)
+        except Exception as exc:  # pragma: no cover - defensive logging
+            return f"{type(payload).__name__} (summary unavailable: {exc})"
+
+    def _build_common_metadata(self, slug: str, data: Mapping[str, Any]) -> dict[str, Any]:
+        metadata: dict[str, Any] = {}
+
+        capabilities = self._derive_capabilities(data)
+        metadata["capabilities"] = capabilities
+
+        imagerouter_meta: dict[str, Any] = {
+            "slug": slug,
+        }
+
+        for key in (
+            "arena_score",
+            "release_date",
+            "output",
+            "sizes",
+        ):
+            value = data.get(key)
+            if value not in (None, "", [], {}):
+                imagerouter_meta[key] = value
+
+        supported_params = data.get("supported_params")
+        if supported_params:
+            imagerouter_meta["supported_params"] = supported_params
+
+        examples = data.get("examples")
+        if isinstance(examples, list) and examples:
+            imagerouter_meta["examples"] = examples
+
+        metadata["imagerouter"] = imagerouter_meta
+        return metadata
+
+    def _derive_capabilities(self, data: Mapping[str, Any]) -> list[str]:
+        capabilities = data.get("capabilities")
+        if isinstance(capabilities, list) and capabilities:
+            return capabilities
+
+        outputs = data.get("output")
+        inferred: set[str] = set()
+        if isinstance(outputs, list):
+            for output in outputs:
+                if isinstance(output, str):
+                    output_key = output.lower()
+                    if "image" in output_key:
+                        inferred.add("image_generation")
+                    if "video" in output_key:
+                        inferred.add("video_generation")
+
+        if not inferred:
+            inferred.add("image_generation")
+
+        return sorted(inferred)
+
+    def _format_model_name(self, slug: str) -> str:
+        candidate = slug.rsplit("/", 1)[-1]
+        candidate = candidate.replace("_", " ").replace("-", " ")
+        if not candidate:
+            return slug
+        return " ".join(part.capitalize() for part in candidate.split())
+
+    def _format_provider_name(self, base_name: str, provider_id: str | None) -> str:
+        if provider_id:
+            provider_label = provider_id.replace("_", " ").title()
+            return f"{base_name} ({provider_label})"
+        return base_name
+
+    def _compose_model_id(
+        self,
+        slug: str,
+        provider_id: str | None,
+        provider_model_name: Any,
+    ) -> str:
+        parts = [slug]
+        if provider_id:
+            parts.append(provider_id)
+        elif provider_model_name:
+            parts.append(str(provider_model_name))
+        return ":".join(parts)
+
+    def _attach_provider_metadata(
+        self,
+        base_metadata: Mapping[str, Any],
+        provider_id: str | None,
+        provider_model_name: Any,
+        pricing: Any,
+    ) -> dict[str, Any]:
+        metadata = dict(base_metadata)
+        metadata["capabilities"] = list(metadata.get("capabilities", [])) or [
+            "image_generation"
+        ]
+        imagerouter_meta = dict(metadata.get("imagerouter", {}))
+
+        if provider_id:
+            imagerouter_meta["provider_id"] = provider_id
+        if provider_model_name not in (None, ""):
+            imagerouter_meta["provider_model_name"] = provider_model_name
+        if pricing not in (None, {}):
+            imagerouter_meta.setdefault("pricing", pricing)
+
+        metadata["imagerouter"] = imagerouter_meta
+        return metadata
 
     async def generate_image(self, prompt: str, model: str, **kwargs: Any) -> dict[str, Any]:
         """Generate an image using ImageRouter API."""

--- a/pocketllm-backend/tests/test_models_filters.py
+++ b/pocketllm-backend/tests/test_models_filters.py
@@ -1,0 +1,123 @@
+"""Ensure the models endpoint supports legacy filter syntax."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+from uuid import uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from app.api.deps import (
+    get_current_request_user,
+    get_database_dependency,
+    get_settings_dependency,
+)
+from app.schemas.auth import TokenPayload
+from app.schemas.providers import ProviderModel, ProviderModelsResponse
+
+
+def _load_app():
+    project_root = Path(__file__).resolve().parents[1]
+    module_path = project_root / "main.py"
+    os.environ.setdefault("ENVIRONMENT", "test")
+    spec = importlib.util.spec_from_file_location("pocketllm_backend.main", module_path)
+    if spec is None or spec.loader is None:  # pragma: no cover - defensive
+        raise RuntimeError("Failed to load FastAPI application")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.app
+
+
+@pytest.fixture()
+def client(monkeypatch):
+    import app.api.v1.endpoints.models as models_endpoint
+
+    app = _load_app()
+    calls: list[dict[str, Any]] = []
+
+    class StubProvidersService:
+        def __init__(self, *args: Any, **kwargs: Any) -> None:  # pragma: no cover - simple stub
+            pass
+
+        async def get_provider_models(
+            self,
+            user_id,
+            *,
+            provider: str | None = None,
+            name: str | None = None,
+            model_id: str | None = None,
+            query: str | None = None,
+        ) -> ProviderModelsResponse:
+            calls.append(
+                {
+                    "user_id": user_id,
+                    "provider": provider,
+                    "name": name,
+                    "model_id": model_id,
+                    "query": query,
+                }
+            )
+            return ProviderModelsResponse(
+                models=[
+                    ProviderModel(
+                        provider="imagerouter",
+                        id="imagerouter-test",
+                        name="ImageRouter Test",
+                    )
+                ],
+                configured_providers=["imagerouter"],
+            )
+
+    monkeypatch.setattr(models_endpoint, "ProvidersService", StubProvidersService)
+
+    async def override_current_user():
+        return TokenPayload(
+            sub=uuid4(),
+            exp=datetime.now(timezone.utc) + timedelta(minutes=5),
+        )
+
+    async def override_settings():
+        return SimpleNamespace()
+
+    async def override_database():
+        return SimpleNamespace()
+
+    app.dependency_overrides[get_current_request_user] = override_current_user
+    app.dependency_overrides[get_settings_dependency] = override_settings
+    app.dependency_overrides[get_database_dependency] = override_database
+
+    test_client = TestClient(app)
+    try:
+        yield test_client, calls
+    finally:
+        app.dependency_overrides.clear()
+
+
+def test_models_endpoint_supports_legacy_filter_path(client):
+    test_client, calls = client
+    response = test_client.get("/v1/models&&provider=imagerouter")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["models"][0]["provider"] == "imagerouter"
+    assert calls
+    assert calls[-1]["provider"] == "imagerouter"
+
+
+def test_legacy_filter_path_parses_optional_filters(client):
+    test_client, calls = client
+    response = test_client.get(
+        "/v1/models&&provider=imagerouter&name=flux&model_id=flux-pro&query=flux"
+    )
+    assert response.status_code == 200
+    assert calls
+    last_call = calls[-1]
+    assert last_call["provider"] == "imagerouter"
+    assert last_call["name"] == "flux"
+    assert last_call["model_id"] == "flux-pro"
+    assert last_call["query"] == "flux"

--- a/pocketllm-backend/tests/test_provider_catalogue.py
+++ b/pocketllm-backend/tests/test_provider_catalogue.py
@@ -199,9 +199,17 @@ def make_provider_record(
     )
 
 class FakeCatalogue:
-    def __init__(self, models: list[ProviderModel]) -> None:
+    def __init__(
+        self,
+        models: list[ProviderModel],
+        *,
+        requires: Mapping[str, bool] | None = None,
+    ) -> None:
         self._models = list(models)
         self.calls: list[tuple[str, Any]] = []
+        self._requires = {
+            key.lower(): bool(value) for key, value in (requires or {}).items()
+        }
 
     async def list_all_models(self, providers: Any = None) -> list[ProviderModel]:
         self.calls.append(("all", providers))
@@ -211,6 +219,9 @@ class FakeCatalogue:
         self.calls.append((provider, providers))
         provider_key = provider.lower()
         return [model for model in self._models if model.provider.lower() == provider_key]
+
+    def provider_requires_api_key(self, provider: str) -> bool:
+        return self._requires.get(provider.lower(), True)
 
 
 def test_normalise_skips_environment_fallback_for_user_configured_provider() -> None:
@@ -405,6 +416,51 @@ async def test_catalogue_handles_provider_errors(caplog):
 
     assert models == []
     assert any("openrouter" in message for message in caplog.text.splitlines())
+
+
+@pytest.mark.asyncio
+async def test_catalogue_uses_imagerouter_fallback_without_api_key():
+    class TrackingImageRouterClient(ImageRouterProviderClient):
+        created: list[dict[str, Any]] = []
+
+        def __init__(
+            self,
+            settings: Settings,
+            *,
+            base_url: str | None = None,
+            api_key: str | None = None,
+            metadata: Mapping[str, Any] | None = None,
+            transport: Any | None = None,
+        ) -> None:
+            type(self).created.append(
+                {
+                    "base_url": base_url,
+                    "api_key": api_key,
+                    "metadata": dict(metadata or {}),
+                }
+            )
+            super().__init__(
+                settings,
+                base_url=base_url,
+                api_key=api_key,
+                metadata=metadata,
+                transport=transport,
+            )
+
+        async def list_models(self) -> list[ProviderModel]:  # pragma: no cover - not exercised
+            return []
+
+    settings = make_settings()
+    TrackingImageRouterClient.created.clear()
+    catalogue = ProviderModelCatalogue(
+        settings,
+        client_factories={"imagerouter": TrackingImageRouterClient},
+    )
+
+    clients = catalogue._get_clients(None)
+
+    assert [client.provider for client in clients] == ["imagerouter"]
+    assert TrackingImageRouterClient.created[-1]["api_key"] is None
 
 
 @pytest.mark.asyncio
@@ -912,6 +968,33 @@ async def test_imagerouter_provider_client_fetches_models_via_http():
 
 
 @pytest.mark.asyncio
+async def test_imagerouter_provider_client_lists_models_without_api_key():
+    payload = {
+        "data": [
+            {
+                "id": "imagerouter/image-public",
+                "name": "Image Public",
+            }
+        ]
+    }
+
+    captured: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request)
+        return httpx.Response(200, json=payload)
+
+    transport = httpx.MockTransport(handler)
+    settings = make_settings()
+    client = ImageRouterProviderClient(settings, transport=transport)
+
+    models = await client.list_models()
+
+    assert [model.id for model in models] == ["imagerouter/image-public"]
+    assert captured and "authorization" not in captured[0].headers
+
+
+@pytest.mark.asyncio
 async def test_imagerouter_provider_client_handles_models_key():
     payload = {
         "models": [
@@ -934,6 +1017,99 @@ async def test_imagerouter_provider_client_handles_models_key():
         "capabilities": ["image_generation"],
         "quality_levels": ["standard", "high"],
     }
+
+
+@pytest.mark.asyncio
+async def test_imagerouter_provider_client_handles_nested_models_payload(caplog):
+    payload = {
+        "data": {
+            "models": [
+                {
+                    "id": "imagerouter/image-nested",
+                    "name": "Image Nested",
+                    "size_options": ["512x512"],
+                }
+            ],
+            "meta": {"page": 1},
+        }
+    }
+
+    transport = httpx.MockTransport(lambda _: httpx.Response(200, json=payload))
+    settings = make_settings()
+    client = ImageRouterProviderClient(settings, transport=transport)
+
+    with caplog.at_level("WARNING"):
+        models = await client.list_models()
+
+    assert [model.id for model in models] == ["imagerouter/image-nested"]
+    assert models[0].metadata == {
+        "capabilities": ["image_generation"],
+        "size_options": ["512x512"],
+    }
+    assert "Unexpected ImageRouter models response format" not in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_imagerouter_provider_client_logs_unexpected_payload_summary(caplog):
+    payload = {"data": {"unexpected": []}}
+    transport = httpx.MockTransport(lambda _: httpx.Response(200, json=payload))
+    settings = make_settings()
+    client = ImageRouterProviderClient(settings, transport=transport)
+
+    with caplog.at_level("WARNING"):
+        models = await client.list_models()
+
+    assert models == []
+    assert "Unexpected ImageRouter models response format" in caplog.text
+    assert "keys=['data']" in caplog.text
+    assert "nested_keys={'data': ['unexpected']}" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_imagerouter_provider_client_parses_catalogue_mapping():
+    payload = {
+        "black-forest-labs/FLUX-1.1-pro": {
+            "providers": [
+                {
+                    "id": "runware",
+                    "model_name": "bfl:2@1",
+                    "pricing": {"type": "post_generation", "value": 0.04},
+                },
+                {
+                    "id": "deepinfra",
+                    "model_name": "black-forest-labs/FLUX-1.1-pro",
+                    "pricing": {"type": "post_generation", "value": 0.04},
+                },
+            ],
+            "arena_score": 1083,
+            "release_date": "2024-11-02",
+            "output": ["image"],
+            "supported_params": {"quality": False, "edit": False},
+        }
+    }
+
+    transport = httpx.MockTransport(lambda _: httpx.Response(200, json=payload))
+    settings = make_settings()
+    client = ImageRouterProviderClient(settings, transport=transport)
+
+    models = await client.list_models()
+
+    assert {model.id for model in models} == {
+        "black-forest-labs/FLUX-1.1-pro:runware",
+        "black-forest-labs/FLUX-1.1-pro:deepinfra",
+    }
+
+    runware = next(model for model in models if model.id.endswith(":runware"))
+    assert runware.name == "Flux 1.1 Pro (Runware)"
+    assert runware.pricing == {"type": "post_generation", "value": 0.04}
+    assert runware.metadata is not None
+    assert runware.metadata["capabilities"] == ["image_generation"]
+    imagerouter_meta = runware.metadata["imagerouter"]
+    assert imagerouter_meta["slug"] == "black-forest-labs/FLUX-1.1-pro"
+    assert imagerouter_meta["provider_id"] == "runware"
+    assert imagerouter_meta["provider_model_name"] == "bfl:2@1"
+    assert imagerouter_meta["pricing"] == {"type": "post_generation", "value": 0.04}
+    assert imagerouter_meta["supported_params"] == {"quality": False, "edit": False}
 
 
 @pytest.mark.asyncio
@@ -1003,6 +1179,64 @@ async def test_providers_service_respects_provider_parameter():
     assert [model.provider for model in groq_models.models] == ["groq"]
     assert catalogue.calls and catalogue.calls[0][0] == "groq"
 
+
+@pytest.mark.asyncio
+async def test_providers_service_exposes_public_imagerouter_catalogue_without_configuration():
+    models = [
+        ProviderModel(provider="imagerouter", id="imagerouter/public", name="Public"),
+    ]
+    catalogue = FakeCatalogue(models, requires={"imagerouter": False})
+    settings = make_settings()
+    service = ProvidersService(settings, database=FakeDatabase(), catalogue=catalogue)
+    user_id = uuid4()
+
+    async def stub_fetch(_: UUID) -> list[ProviderRecord]:
+        return []
+
+    service._fetch_provider_records = stub_fetch  # type: ignore[assignment]
+
+    response = await service.get_provider_models(user_id, provider="imagerouter")
+
+    assert [model.id for model in response.models] == ["imagerouter/public"]
+    assert response.using_fallback is True
+    assert response.message and "public catalogue" in response.message.lower()
+    assert catalogue.calls and catalogue.calls[0][0] == "imagerouter"
+
+
+@pytest.mark.asyncio
+async def test_providers_service_accepts_optional_provider_without_api_key():
+    model = ProviderModel(provider="imagerouter", id="imagerouter/live", name="Live")
+    catalogue = FakeCatalogue([model], requires={"imagerouter": False})
+    settings = make_settings()
+    service = ProvidersService(settings, database=FakeDatabase(), catalogue=catalogue)
+    user_id = uuid4()
+    now = datetime.now(tz=UTC)
+
+    provider_record = ProviderRecord(
+        id=uuid4(),
+        user_id=user_id,
+        provider="imagerouter",
+        display_name=None,
+        base_url=None,
+        metadata=None,
+        api_key_hash=None,
+        api_key_preview=None,
+        api_key_encrypted=None,
+        is_active=True,
+        created_at=now,
+        updated_at=now,
+        api_key=None,
+    )
+
+    async def stub_fetch(_: UUID) -> list[ProviderRecord]:
+        return [provider_record]
+
+    service._fetch_provider_records = stub_fetch  # type: ignore[assignment]
+
+    response = await service.get_provider_models(user_id, provider="imagerouter")
+
+    assert [returned.id for returned in response.models] == ["imagerouter/live"]
+    assert catalogue.calls and catalogue.calls[0][1]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- treat ImageRouter catalogue mappings keyed by model slug as first-class entries and emit provider-specific models with rich metadata
- derive sensible names, capabilities, and pricing details for ImageRouter providers while keeping legacy list payload support intact
- cover the mapping scenario with a dedicated ImageRouter catalogue test to prevent regressions

## Testing
- pytest pocketllm-backend/tests/test_models_filters.py
- pytest pocketllm-backend/tests/test_provider_catalogue.py::test_imagerouter_provider_client_parses_catalogue_mapping *(fails: async tests require an asyncio plugin such as pytest-asyncio in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_6902003634a4832db9d89b3f1e9eb1d7