### PR TITLE
Revamp onboarding animations and layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,5 +132,11 @@ echo "✅ Setup completed for $APP_NAME"
    constraints). This keeps the project aligned with the team's dependency
    management approach.
 
+**Onboarding Flow Notes**
+
+- Render onboarding content directly on the page—avoid wrapping steps in card-like
+  containers—and preserve smooth animations for screen transitions and progress
+  indicators.
+
 **Remember**: The goal is to maintain a high-quality, production-ready codebase that is well-documented and thoroughly tested.
 ```

--- a/lib/component/onboarding_screens/widgets/onboarding_step.dart
+++ b/lib/component/onboarding_screens/widgets/onboarding_step.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 
-/// Reusable card-based layout that renders each onboarding step with
-/// consistent spacing, typography, and navigation controls.
+/// Reusable layout that renders each onboarding step with consistent spacing,
+/// typography, and navigation controls. The content now sits directly on the
+/// page without being wrapped in decorative containers so the experience feels
+/// lighter and faster.
 class OnboardingStep extends StatelessWidget {
   const OnboardingStep({
     required this.illustrationAsset,
@@ -39,8 +41,9 @@ class OnboardingStep extends StatelessWidget {
 
     return SafeArea(
       child: Padding(
-        padding: const EdgeInsets.all(24),
+        padding: const EdgeInsets.symmetric(horizontal: 24, vertical: 16),
         child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
           children: [
             Align(
               alignment: Alignment.centerLeft,
@@ -55,78 +58,87 @@ class OnboardingStep extends StatelessWidget {
                 ),
               ),
             ),
+            const SizedBox(height: 8),
             Expanded(
-              child: Center(
-                child: ConstrainedBox(
-                  constraints: const BoxConstraints(maxWidth: 560),
-                  child: Card(
-                    clipBehavior: Clip.antiAlias,
-                    elevation: 8,
-                    shape: RoundedRectangleBorder(
-                      borderRadius: BorderRadius.circular(28),
-                    ),
-                    child: LayoutBuilder(
-                      builder: (context, constraints) {
-                        return SingleChildScrollView(
-                          padding: const EdgeInsets.fromLTRB(24, 32, 24, 24),
-                          child: Column(
-                            crossAxisAlignment: CrossAxisAlignment.stretch,
-                            children: [
-                              ClipRRect(
-                                borderRadius: BorderRadius.circular(24),
-                                child: Container(
-                                  color: theme.colorScheme.surfaceVariant,
-                                  padding: const EdgeInsets.all(16),
-                                  child: Image.asset(
-                                    illustrationAsset,
-                                    fit: BoxFit.contain,
-                                    height: constraints.maxWidth > 420 ? 260 : 200,
-                                    semanticLabel: title,
+              child: LayoutBuilder(
+                builder: (context, constraints) {
+                  final maxContentWidth = constraints.maxWidth >= 720 ? 640.0 : constraints.maxWidth;
+
+                  return Align(
+                    alignment: Alignment.topCenter,
+                    child: AnimatedSize(
+                      duration: const Duration(milliseconds: 350),
+                      curve: Curves.easeInOut,
+                      child: ConstrainedBox(
+                        constraints: BoxConstraints(maxWidth: maxContentWidth),
+                        child: SingleChildScrollView(
+                          padding: const EdgeInsets.symmetric(horizontal: 4, vertical: 12),
+                          child: AnimatedSwitcher(
+                            duration: const Duration(milliseconds: 300),
+                            switchInCurve: Curves.easeInOut,
+                            switchOutCurve: Curves.easeInOut,
+                            child: Column(
+                              key: ValueKey(title),
+                              crossAxisAlignment: CrossAxisAlignment.stretch,
+                              children: [
+                                _Illustration(illustrationAsset: illustrationAsset, title: title),
+                                const SizedBox(height: 28),
+                                Text(
+                                  title,
+                                  style: GoogleFonts.plusJakartaSans(
+                                    textStyle: theme.textTheme.headlineMedium,
+                                    fontWeight: FontWeight.w700,
+                                    letterSpacing: -0.3,
                                   ),
                                 ),
-                              ),
-                              const SizedBox(height: 28),
-                              Text(
-                                title,
-                                style: GoogleFonts.plusJakartaSans(
-                                  textStyle: theme.textTheme.headlineMedium,
-                                  fontWeight: FontWeight.w700,
-                                  letterSpacing: -0.3,
+                                const SizedBox(height: 12),
+                                Text(
+                                  subtitle,
+                                  style: GoogleFonts.inter(
+                                    textStyle: theme.textTheme.bodyLarge,
+                                    height: 1.4,
+                                    color: theme.colorScheme.onSurface.withOpacity(0.78),
+                                  ),
                                 ),
-                              ),
-                              const SizedBox(height: 12),
-                              Text(
-                                subtitle,
-                                style: GoogleFonts.inter(
-                                  textStyle: theme.textTheme.bodyLarge,
-                                  height: 1.4,
-                                  color: theme.colorScheme.onSurface.withOpacity(0.78),
-                                ),
-                              ),
-                              if (body != null) ...[
-                                const SizedBox(height: 24),
-                                body!,
+                                if (body != null) ...[
+                                  const SizedBox(height: 24),
+                                  AnimatedSwitcher(
+                                    duration: const Duration(milliseconds: 300),
+                                    switchInCurve: Curves.easeOut,
+                                    switchOutCurve: Curves.easeIn,
+                                    child: KeyedSubtree(
+                                      key: ValueKey('body-$currentStep'),
+                                      child: body!,
+                                    ),
+                                  ),
+                                ],
+                                if (footer != null) ...[
+                                  const SizedBox(height: 24),
+                                  AnimatedSwitcher(
+                                    duration: const Duration(milliseconds: 300),
+                                    child: KeyedSubtree(
+                                      key: ValueKey('footer-$currentStep'),
+                                      child: footer!,
+                                    ),
+                                  ),
+                                ],
                               ],
-                              if (footer != null) ...[
-                                const SizedBox(height: 24),
-                                footer!,
-                              ],
-                            ],
+                            ),
                           ),
-                        );
-                      },
+                        ),
+                      ),
                     ),
-                  ),
-                ),
+                  );
+                },
               ),
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 24),
             _ProgressDots(
               currentStep: currentStep,
               totalSteps: totalSteps,
               color: theme.colorScheme.primary,
             ),
-            const SizedBox(height: 16),
+            const SizedBox(height: 20),
             Row(
               children: [
                 if (showPrevious)
@@ -150,6 +162,47 @@ class OnboardingStep extends StatelessWidget {
   }
 }
 
+class _Illustration extends StatelessWidget {
+  const _Illustration({
+    required this.illustrationAsset,
+    required this.title,
+  });
+
+  final String illustrationAsset;
+  final String title;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final isWide = MediaQuery.of(context).size.width > 480;
+    final targetHeight = isWide ? 260.0 : 200.0;
+
+    return AnimatedSwitcher(
+      duration: const Duration(milliseconds: 400),
+      switchInCurve: Curves.easeOut,
+      switchOutCurve: Curves.easeIn,
+      child: ClipRRect(
+        key: ValueKey(illustrationAsset),
+        borderRadius: BorderRadius.circular(28),
+        child: DecoratedBox(
+          decoration: BoxDecoration(
+            color: theme.colorScheme.surfaceVariant,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(20),
+            child: Image.asset(
+              illustrationAsset,
+              fit: BoxFit.contain,
+              height: targetHeight,
+              semanticLabel: title,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _ProgressDots extends StatelessWidget {
   const _ProgressDots({
     required this.currentStep,
@@ -167,14 +220,24 @@ class _ProgressDots extends StatelessWidget {
       mainAxisAlignment: MainAxisAlignment.center,
       children: List.generate(totalSteps, (index) {
         final bool isActive = index == currentStep;
-        return AnimatedContainer(
+        return AnimatedOpacity(
           duration: const Duration(milliseconds: 250),
-          margin: const EdgeInsets.symmetric(horizontal: 4),
-          height: 10,
-          width: isActive ? 24 : 10,
-          decoration: BoxDecoration(
-            color: isActive ? color : color.withOpacity(0.25),
-            borderRadius: BorderRadius.circular(20),
+          opacity: isActive ? 1 : 0.45,
+          child: AnimatedScale(
+            duration: const Duration(milliseconds: 250),
+            scale: isActive ? 1.05 : 0.9,
+            curve: Curves.easeInOut,
+            child: AnimatedContainer(
+              duration: const Duration(milliseconds: 300),
+              curve: Curves.easeInOut,
+              margin: const EdgeInsets.symmetric(horizontal: 4),
+              height: 10,
+              width: isActive ? 28 : 10,
+              decoration: BoxDecoration(
+                color: isActive ? color : color.withOpacity(0.25),
+                borderRadius: BorderRadius.circular(20),
+              ),
+            ),
           ),
         );
       }),


### PR DESCRIPTION
## Summary
- animate onboarding transitions and progress indicators for a smoother experience
- rework onboarding pages to render content directly on the page without card containers
- update the provider step to be informational and defer API key setup until later

## Testing
- flutter test *(fails: flutter not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_69020f935c08832d92adf827c97bf9c1