### PR TITLE
Update provider and model clients for hosted API

### DIFF
--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -458,20 +458,24 @@ class ProviderStatusInfo {
     String? _string(dynamic value) => value is String ? value : null;
 
     final providerId = _string(json['provider']) ?? '';
+    final provider = ModelProviderExtension.fromBackend(providerId);
+
+    String fallbackName() {
+      if (providerId.isEmpty) {
+        return provider.displayName;
+      }
+      final normalizedId = providerId.toLowerCase();
+      if (normalizedId == provider.backendId.toLowerCase()) {
+        return provider.displayName;
+      }
+      return providerId;
+    }
+
     return ProviderStatusInfo(
-      provider: ModelProviderExtension.fromBackend(providerId),
+      provider: provider,
       displayName: _string(json['displayName']) ??
           _string(json['display_name']) ??
-          (() {
-            if (providerId.isEmpty) {
-              return provider.displayName;
-            }
-            final normalizedId = providerId.toLowerCase();
-            if (normalizedId == provider.backendId.toLowerCase()) {
-              return provider.displayName;
-            }
-            return providerId;
-          })(),
+          fallbackName(),
       configured: json['configured'] == true || json['is_configured'] == true,
       isActive: json['isActive'] == true || json['is_active'] == true,
       hasApiKey: json['hasApiKey'] == true || json['has_api_key'] == true,

--- a/lib/component/models.dart
+++ b/lib/component/models.dart
@@ -381,20 +381,56 @@ class ProviderConnection {
   });
 
   factory ProviderConnection.fromJson(Map<String, dynamic> json) {
+    Map<String, dynamic>? _asMap(dynamic value) {
+      if (value is Map<String, dynamic>) {
+        return value;
+      }
+      if (value is Map) {
+        return value.map(
+          (key, dynamic v) => MapEntry(key.toString(), v),
+        );
+      }
+      return null;
+    }
+
+    String? _string(dynamic value) => value is String ? value : null;
+
+    final providerId = _string(json['provider']) ?? '';
+    final provider = providerId.isNotEmpty
+        ? ModelProviderExtension.fromBackend(providerId)
+        : ModelProvider.pocketLLM;
+
+    String fallbackName() {
+      if (providerId.isEmpty) {
+        return provider.displayName;
+      }
+      final normalizedId = providerId.toLowerCase();
+      if (normalizedId == provider.backendId.toLowerCase()) {
+        return provider.displayName;
+      }
+      return providerId;
+    }
+
+    final displayName = _string(json['displayName']) ??
+        _string(json['display_name']) ??
+        fallbackName();
+
+    final baseUrl = _string(json['baseUrl']) ?? _string(json['base_url']);
+    final metadata = _asMap(json['metadata']);
+    final apiKeyPreview =
+        _string(json['apiKeyPreview']) ?? _string(json['api_key_preview']);
+    final statusMessage = _string(json['message']) ?? _string(json['status_message']);
+
     return ProviderConnection(
-      id: json['id'] ?? '',
-      provider: json['provider'] != null
-          ? ModelProviderExtension.fromBackend(json['provider'])
-          : ModelProvider.pocketLLM,
-      displayName: json['displayName'] ?? json['provider'] ?? '',
-      baseUrl: json['baseUrl'],
-      isActive: json['isActive'] ?? false,
-      hasApiKey: json['hasApiKey'] ?? false,
-      apiKeyPreview: json['apiKeyPreview'],
-      metadata: json['metadata'] != null
-          ? Map<String, dynamic>.from(json['metadata'])
-          : null,
-      statusMessage: json['message'] as String?,
+      id: _string(json['id']) ?? '',
+      provider: provider,
+      displayName: displayName,
+      baseUrl: baseUrl,
+      isActive: json['isActive'] == true || json['is_active'] == true,
+      hasApiKey: json['hasApiKey'] == true || json['has_api_key'] == true,
+      apiKeyPreview: apiKeyPreview,
+      metadata: metadata,
+      statusMessage: statusMessage,
     );
   }
 }
@@ -419,15 +455,29 @@ class ProviderStatusInfo {
   });
 
   factory ProviderStatusInfo.fromJson(Map<String, dynamic> json) {
-    final providerId = json['provider'] as String? ?? '';
+    String? _string(dynamic value) => value is String ? value : null;
+
+    final providerId = _string(json['provider']) ?? '';
     return ProviderStatusInfo(
       provider: ModelProviderExtension.fromBackend(providerId),
-      displayName: json['displayName'] as String? ?? providerId,
-      configured: json['configured'] ?? false,
-      isActive: json['isActive'] ?? false,
-      hasApiKey: json['hasApiKey'] ?? false,
-      apiKeyPreview: json['apiKeyPreview'] as String?,
-      message: json['message'] as String? ?? '',
+      displayName: _string(json['displayName']) ??
+          _string(json['display_name']) ??
+          (() {
+            if (providerId.isEmpty) {
+              return provider.displayName;
+            }
+            final normalizedId = providerId.toLowerCase();
+            if (normalizedId == provider.backendId.toLowerCase()) {
+              return provider.displayName;
+            }
+            return providerId;
+          })(),
+      configured: json['configured'] == true || json['is_configured'] == true,
+      isActive: json['isActive'] == true || json['is_active'] == true,
+      hasApiKey: json['hasApiKey'] == true || json['has_api_key'] == true,
+      apiKeyPreview: _string(json['apiKeyPreview']) ??
+          _string(json['api_key_preview']),
+      message: _string(json['message']) ?? _string(json['status_message']) ?? '',
     );
   }
 }
@@ -543,6 +593,53 @@ class ModelConfig {
   }
 
   factory ModelConfig.fromJson(Map<String, dynamic> json) {
+    Map<String, dynamic>? _asMap(dynamic value) {
+      if (value is Map<String, dynamic>) {
+        return value;
+      }
+      if (value is Map) {
+        return value.map(
+          (key, dynamic v) => MapEntry(key.toString(), v),
+        );
+      }
+      return null;
+    }
+
+    String? _string(dynamic value) => value is String ? value : null;
+
+    double? _double(dynamic value) {
+      if (value is num) {
+        return value.toDouble();
+      }
+      if (value is String) {
+        return double.tryParse(value);
+      }
+      return null;
+    }
+
+    int? _int(dynamic value) {
+      if (value is num) {
+        return value.toInt();
+      }
+      if (value is String) {
+        return int.tryParse(value);
+      }
+      return null;
+    }
+
+    DateTime _parseDate(dynamic value) {
+      if (value is int) {
+        return DateTime.fromMillisecondsSinceEpoch(value);
+      }
+      if (value is String) {
+        return DateTime.tryParse(value) ?? DateTime.now();
+      }
+      if (value is DateTime) {
+        return value;
+      }
+      return DateTime.now();
+    }
+
     final providerValue = json['provider'];
     final ModelProvider provider;
     if (providerValue is int) {
@@ -553,40 +650,90 @@ class ModelConfig {
       provider = ModelProvider.pocketLLM;
     }
 
-    DateTime parseDate(dynamic value) {
-      if (value is int) {
-        return DateTime.fromMillisecondsSinceEpoch(value);
-      }
-      if (value is String) {
-        return DateTime.tryParse(value) ?? DateTime.now();
-      }
-      return DateTime.now();
+    final providerDetails =
+        _asMap(json['providerDetails']) ?? _asMap(json['provider_details']);
+    final settings =
+        _asMap(json['settings']) ?? _asMap(json['modelSettings']);
+
+    final metadata = Map<String, dynamic>.from(
+      _asMap(json['metadata']) ?? const <String, dynamic>{},
+    );
+    final additionalParams = Map<String, dynamic>.from(
+      _asMap(json['additionalParams']) ?? const <String, dynamic>{},
+    );
+
+    final systemPrompt = _string(settings?['system_prompt']) ??
+        _string(json['systemPrompt']);
+    final temperature =
+        _double(settings?['temperature']) ?? _double(json['temperature']) ?? 0.7;
+    final maxTokens =
+        _int(settings?['max_tokens']) ?? _int(json['maxTokens']);
+    final topP =
+        _double(settings?['top_p']) ?? _double(json['topP']) ?? 1.0;
+    final frequencyPenalty =
+        _double(settings?['frequency_penalty']) ??
+        _double(json['frequencyPenalty']) ??
+        0.0;
+    final presencePenalty =
+        _double(settings?['presence_penalty']) ??
+        _double(json['presencePenalty']) ??
+        0.0;
+
+    final settingsMetadata = _asMap(settings?['metadata']);
+    if (settingsMetadata != null) {
+      metadata.addAll(settingsMetadata);
     }
+
+    if (settings != null) {
+      additionalParams.addAll(settings);
+      additionalParams.removeWhere((key, _) =>
+          {
+            'temperature',
+            'max_tokens',
+            'top_p',
+            'frequency_penalty',
+            'presence_penalty',
+            'system_prompt',
+            'metadata',
+          }.contains(key));
+    }
+
+    if (json['description'] != null && metadata['description'] == null) {
+      metadata['description'] = json['description'];
+    }
+
+    final baseUrl = _string(json['baseUrl']) ??
+        _string(json['base_url']) ??
+        _string(providerDetails?['baseUrl']) ??
+        _string(providerDetails?['base_url']) ??
+        provider.defaultBaseUrl;
+
+    final modelName = _string(json['display_name']) ??
+        _string(json['name']) ??
+        _string(json['model']) ??
+        'Model';
 
     return ModelConfig(
       id: json['id'],
-      name: json['name'],
+      name: modelName,
       provider: provider,
-      providerId: json['providerId'] ?? json['provider_id'],
-      baseUrl: json['baseUrl'],
-      apiKey: json['apiKey'],
-      model: json['model'],
-      systemPrompt: json['systemPrompt'],
-      temperature: json['temperature'] ?? 0.7,
-      maxTokens: json['maxTokens'] ?? 2048,
-      topP: json['topP'] ?? 1.0,
-      frequencyPenalty: json['frequencyPenalty'] ?? 0.0,
-      presencePenalty: json['presencePenalty'] ?? 0.0,
-      additionalParams: json['additionalParams'] != null
-          ? Map<String, dynamic>.from(json['additionalParams'])
-          : null,
-      metadata: json['metadata'] != null
-          ? Map<String, dynamic>.from(json['metadata'])
-          : null,
+      providerId: _string(json['providerId']) ?? _string(json['provider_id']),
+      baseUrl: baseUrl,
+      apiKey: _string(json['apiKey']) ?? _string(json['api_key']),
+      model: _string(json['model']) ?? modelName,
+      systemPrompt: systemPrompt,
+      temperature: temperature,
+      maxTokens: maxTokens,
+      topP: topP,
+      frequencyPenalty: frequencyPenalty,
+      presencePenalty: presencePenalty,
+      additionalParams:
+          additionalParams.isEmpty ? null : Map<String, dynamic>.from(additionalParams),
+      metadata: metadata.isEmpty ? null : Map<String, dynamic>.from(metadata),
       isDefault: json['isDefault'] == true || json['is_default'] == true,
-      isActive: json['isActive'] ?? true,
-      createdAt: parseDate(json['createdAt']),
-      updatedAt: parseDate(json['updatedAt']),
+      isActive: json['isActive'] != false && json['is_active'] != false,
+      createdAt: _parseDate(json['createdAt'] ?? json['created_at']),
+      updatedAt: _parseDate(json['updatedAt'] ?? json['updated_at']),
     );
   }
 

--- a/lib/services/model_service.dart
+++ b/lib/services/model_service.dart
@@ -117,6 +117,28 @@ class ModelService {
     await _refreshCache();
   }
 
+  Future<ModelConfig> getModelDetails(String modelId) async {
+    try {
+      final model = await _remoteModelService.getModelDetails(modelId);
+      final updated = List<ModelConfig>.from(_cachedModels);
+      final existingIndex = updated.indexWhere((item) => item.id == model.id);
+      if (existingIndex >= 0) {
+        updated[existingIndex] = model;
+      } else {
+        updated.add(model);
+      }
+      _cachedModels = updated;
+      _cacheInitialized = true;
+      if (model.isDefault) {
+        _defaultModelId = model.id;
+      }
+      return model;
+    } catch (e) {
+      debugPrint('Remote getModelDetails failed: $e');
+      rethrow;
+    }
+  }
+
   Future<List<ProviderConnection>> getProviders() async {
     try {
       final configurations = await _remoteModelService.getProviderConfigurations();

--- a/lib/services/remote_model_service.dart
+++ b/lib/services/remote_model_service.dart
@@ -140,6 +140,15 @@ class RemoteModelService {
     return models.map((raw) => _mapModel(Map<String, dynamic>.from(raw as Map))).toList();
   }
 
+  Future<ModelConfig> getModelDetails(String modelId) async {
+    final data = await _api.get('models/$modelId');
+    final payload = _castMap(data);
+    if (payload == null) {
+      throw StateError('Unexpected response when fetching model details: $data');
+    }
+    return _mapModel(payload);
+  }
+
   Future<AvailableModelsResponse> getAvailableModels({
     ModelProvider? provider,
     String? query,

--- a/lib/services/remote_model_service.dart
+++ b/lib/services/remote_model_service.dart
@@ -14,6 +14,51 @@ class RemoteModelService {
 
   final BackendApiService _api = BackendApiService();
 
+  Map<String, dynamic>? _castMap(dynamic value) {
+    if (value is Map<String, dynamic>) {
+      return value;
+    }
+    if (value is Map) {
+      return value.map(
+        (key, dynamic v) => MapEntry(key.toString(), v),
+      );
+    }
+    return null;
+  }
+
+  Map<String, dynamic>? _convertSettings(Map<String, dynamic>? settings) {
+    if (settings == null || settings.isEmpty) {
+      return null;
+    }
+
+    final map = _castMap(settings) ?? settings;
+    if (map == null || map.isEmpty) {
+      return null;
+    }
+
+    final normalized = <String, dynamic>{};
+
+    void assign(String key, dynamic value) {
+      if (value != null) {
+        normalized[key] = value;
+      }
+    }
+
+    assign('temperature', map['temperature']);
+    assign('max_tokens', map['maxTokens'] ?? map['max_tokens']);
+    assign('top_p', map['topP'] ?? map['top_p']);
+    assign('frequency_penalty', map['frequencyPenalty'] ?? map['frequency_penalty']);
+    assign('presence_penalty', map['presencePenalty'] ?? map['presence_penalty']);
+    assign('system_prompt', map['systemPrompt'] ?? map['system_prompt']);
+
+    final metadata = map['metadata'];
+    if (metadata != null) {
+      normalized['metadata'] = metadata;
+    }
+
+    return normalized.isEmpty ? null : normalized;
+  }
+
   Future<List<ProviderConnection>> getProviderConfigurations() async {
     try {
       final data = await _api.get('providers');
@@ -45,13 +90,13 @@ class RemoteModelService {
     final trimmedBaseUrl = baseUrl?.trim();
     final body = {
       'provider': provider.backendId,
-      if (trimmedApiKey != null && trimmedApiKey.isNotEmpty) 'apiKey': trimmedApiKey,
-      if (trimmedBaseUrl != null && trimmedBaseUrl.isNotEmpty) 'baseUrl': trimmedBaseUrl,
+      if (trimmedApiKey != null && trimmedApiKey.isNotEmpty) 'api_key': trimmedApiKey,
+      if (trimmedBaseUrl != null && trimmedBaseUrl.isNotEmpty) 'base_url': trimmedBaseUrl,
       if (metadata != null) 'metadata': metadata,
     };
 
     final data = await _api.post('providers/activate', body: body);
-    return ProviderConnection.fromJson(Map<String, dynamic>.from(data as Map));
+    return _parseProviderConnection(data);
   }
 
   Future<ProviderConnection> updateProvider({
@@ -67,22 +112,22 @@ class RemoteModelService {
     final trimmedBaseUrl = baseUrl?.trim();
 
     if (removeApiKey) {
-      body['apiKey'] = null;
+      body['api_key'] = null;
     } else if (trimmedApiKey != null && trimmedApiKey.isNotEmpty) {
-      body['apiKey'] = trimmedApiKey;
+      body['api_key'] = trimmedApiKey;
     }
     if (trimmedBaseUrl != null && trimmedBaseUrl.isNotEmpty) {
-      body['baseUrl'] = trimmedBaseUrl;
+      body['base_url'] = trimmedBaseUrl;
     }
     if (metadata != null) {
       body['metadata'] = metadata;
     }
     if (isActive != null) {
-      body['isActive'] = isActive;
+      body['is_active'] = isActive;
     }
 
     final data = await _api.patch('providers/${provider.backendId}', body: body);
-    return ProviderConnection.fromJson(Map<String, dynamic>.from(data as Map));
+    return _parseProviderConnection(data);
   }
 
   Future<void> deactivateProvider(ModelProvider provider) async {
@@ -170,18 +215,13 @@ class RemoteModelService {
     String? providerId,
     Map<String, dynamic>? sharedSettings,
   }) async {
+    final normalizedSettings = _convertSettings(sharedSettings);
     final body = {
       'provider': provider.backendId,
-      if (providerId != null) 'providerId': providerId,
-      'models': selections
-          .map((model) => {
-                'id': model.id,
-                'name': model.name,
-                'description': model.description,
-                'metadata': model.metadata,
-              })
-          .toList(),
-      if (sharedSettings != null) 'sharedSettings': sharedSettings,
+      if (providerId != null && providerId.isNotEmpty) 'provider_id': providerId,
+      'models': selections.map((model) => model.id).toList(),
+      'sync': true,
+      if (normalizedSettings != null) 'settings': normalizedSettings,
     };
 
     final data = await _api.post('models/import', body: body);
@@ -205,12 +245,18 @@ class RemoteModelService {
     required ModelProvider provider,
     String? search,
   }) async {
+    final query = <String, String>{};
+    if (search != null && search.trim().isNotEmpty) {
+      query['query'] = search.trim();
+    }
+
     final data = await _api.get(
       'providers/${provider.backendId}/models',
-      query: search != null && search.isNotEmpty ? {'search': search} : null,
+      query: query.isEmpty ? null : query,
     );
 
-    final models = (data as List?) ?? [];
+    final payloadMap = _normalizeCataloguePayload(data);
+    final models = (payloadMap['models'] as List?) ?? const <dynamic>[];
     return models
         .map((entry) => AvailableModelOption.fromJson(
               Map<String, dynamic>.from(entry as Map),
@@ -220,46 +266,20 @@ class RemoteModelService {
   }
 
   ModelConfig _mapModel(Map<String, dynamic> json) {
-    final providerDetails = json['providerDetails'] as Map<String, dynamic>?;
-    final baseUrl = json['baseUrl'] as String? ??
-        providerDetails?['baseUrl'] as String? ??
-        ModelProviderExtension.fromBackend(json['provider']).defaultBaseUrl;
+    return ModelConfig.fromJson(json);
+  }
 
-    DateTime parseDate(dynamic value) {
-      if (value is int) {
-        return DateTime.fromMillisecondsSinceEpoch(value);
-      }
-      if (value is String) {
-        return DateTime.tryParse(value) ?? DateTime.now();
-      }
-      return DateTime.now();
+  ProviderConnection _parseProviderConnection(dynamic payload) {
+    final normalized = _castMap(payload);
+    if (normalized == null) {
+      throw StateError('Unexpected provider response: $payload');
     }
 
-    return ModelConfig(
-      id: json['id'],
-      name: json['displayName'] ?? json['name'],
-      provider: ModelProviderExtension.fromBackend(json['provider']),
-      providerId: json['providerId'],
-      baseUrl: baseUrl,
-      model: json['model'],
-      systemPrompt: json['systemPrompt'],
-      temperature: json['temperature'] is num ? (json['temperature'] as num).toDouble() : 0.7,
-      maxTokens: json['maxTokens'] is num ? (json['maxTokens'] as num).toInt() : null,
-      topP: json['topP'] is num ? (json['topP'] as num).toDouble() : 1.0,
-      frequencyPenalty:
-          json['frequencyPenalty'] is num ? (json['frequencyPenalty'] as num).toDouble() : 0.0,
-      presencePenalty:
-          json['presencePenalty'] is num ? (json['presencePenalty'] as num).toDouble() : 0.0,
-      additionalParams: json['additionalParams'] != null
-          ? Map<String, dynamic>.from(json['additionalParams'] as Map)
-          : null,
-      metadata: json['metadata'] != null
-          ? Map<String, dynamic>.from(json['metadata'] as Map)
-          : null,
-      isDefault: json['isDefault'] == true,
-      isActive: json['isActive'] ?? true,
-      createdAt: parseDate(json['createdAt']),
-      updatedAt: parseDate(json['updatedAt']),
-    );
+    final providerPayload = _castMap(normalized['provider']);
+    if (providerPayload != null) {
+      return ProviderConnection.fromJson(providerPayload);
+    }
+
+    return ProviderConnection.fromJson(normalized);
   }
 }


### PR DESCRIPTION
## Summary
- normalize provider and model JSON parsing to handle hosted API field names and nested payloads
- update the remote model service to call the new endpoints, translate settings, and reuse the shared model mapper
- streamline the model settings screen so the + action opens the model library and refreshes after imports

## Testing
- ./setup.sh *(fails: file not present in repository)*
- flutter analyze *(fails: flutter is not installed in the container)*
- flutter test *(fails: flutter is not installed in the container)*
- flutter build apk --debug *(fails: flutter is not installed in the container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d860a6e8c832d9f9c78153c26255e)