### PR TITLE
Add Anthropic, DeepSeek, and Mistral AI provider integrations

### DIFF
--- a/pocketllm-backend/app/core/config.py
+++ b/pocketllm-backend/app/core/config.py
@@ -83,6 +83,12 @@ class Settings(BaseSettings):
     openrouter_app_name: str | None = Field(default=None, alias="OPENROUTER_APP_NAME")
     imagerouter_api_key: str | None = Field(default=None, alias="IMAGEROUTER_API_KEY")
     imagerouter_api_base: str | None = Field(default=None, alias="IMAGEROUTER_API_BASE")
+    anthropic_api_key: str | None = Field(default=None, alias="ANTHROPIC_API_KEY")
+    anthropic_api_base: str | None = Field(default=None, alias="ANTHROPIC_API_BASE")
+    deepseek_api_key: str | None = Field(default=None, alias="DEEPSEEK_API_KEY")
+    deepseek_api_base: str | None = Field(default=None, alias="DEEPSEEK_API_BASE")
+    mistral_api_key: str | None = Field(default=None, alias="MISTRAL_API_KEY")
+    mistral_api_base: str | None = Field(default=None, alias="MISTRAL_API_BASE")
     provider_catalogue_cache_ttl: int = Field(
         default=300, alias="PROVIDER_CATALOGUE_CACHE_TTL"
     )

--- a/pocketllm-backend/app/services/providers/__init__.py
+++ b/pocketllm-backend/app/services/providers/__init__.py
@@ -2,17 +2,23 @@
 
 from .base import ProviderClient
 from .catalogue import ProviderModelCatalogue
+from .anthropic import AnthropicProviderClient
 from .groq import GroqProviderClient, GroqSDKService
 from .imagerouter import ImageRouterProviderClient
+from .mistral import MistralProviderClient
 from .openai import OpenAIProviderClient
 from .openrouter import OpenRouterProviderClient
+from .deepseek import DeepSeekProviderClient
 
 __all__ = [
     "ProviderClient",
     "ProviderModelCatalogue",
+    "AnthropicProviderClient",
     "GroqProviderClient",
     "GroqSDKService",
     "OpenAIProviderClient",
     "OpenRouterProviderClient",
     "ImageRouterProviderClient",
+    "DeepSeekProviderClient",
+    "MistralProviderClient",
 ]

--- a/pocketllm-backend/app/services/providers/anthropic.py
+++ b/pocketllm-backend/app/services/providers/anthropic.py
@@ -1,0 +1,314 @@
+"""Anthropic provider client implementation backed by the official SDK."""
+
+from __future__ import annotations
+
+import inspect
+from collections.abc import Iterable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from typing import Any, Callable
+
+import httpx
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+
+from .base import ProviderClient
+
+try:  # pragma: no cover - exercised in production environments
+    from anthropic import AsyncAnthropic
+except Exception:  # pragma: no cover - defensive fallback for environments without the SDK
+    AsyncAnthropic = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - exercised in production environments
+    from anthropic import APIError as AnthropicAPIError
+except Exception:  # pragma: no cover - compatibility with alternate SDK versions
+    try:  # pragma: no cover - alternate error type
+        from anthropic import AnthropicError as AnthropicAPIError  # type: ignore
+    except Exception:  # pragma: no cover - defensive fallback
+        class AnthropicAPIError(Exception):
+            """Fallback error raised when the Anthropic SDK is unavailable."""
+
+
+ClientFactory = Callable[..., Any]
+
+
+def _default_client_factory(**kwargs: Any) -> Any:
+    if AsyncAnthropic is None:
+        raise RuntimeError(
+            "The 'anthropic' package is required to use the Anthropic provider client. Install it via 'pip install anthropic'."
+        )
+    return AsyncAnthropic(**kwargs)
+
+
+async def _close_client(client: Any) -> None:
+    for attr in ("aclose", "close"):
+        close_callable = getattr(client, attr, None)
+        if callable(close_callable):
+            result = close_callable()
+            if inspect.isawaitable(result):
+                await result
+            return
+
+
+@asynccontextmanager
+async def _client_context(factory: ClientFactory, **kwargs: Any):
+    client = factory(**kwargs)
+    aenter = getattr(client, "__aenter__", None)
+    if callable(aenter):
+        try:
+            entered = aenter()
+            if inspect.isawaitable(entered):
+                entered = await entered
+            yield entered
+        finally:
+            aexit = getattr(client, "__aexit__", None)
+            if callable(aexit):
+                exit_result = aexit(None, None, None)
+                if inspect.isawaitable(exit_result):
+                    await exit_result
+    else:
+        try:
+            yield client
+        finally:
+            await _close_client(client)
+
+
+def _build_client_kwargs(
+    api_key: str | None,
+    base_url: str | None,
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if api_key:
+        kwargs["api_key"] = api_key
+    if base_url:
+        kwargs["base_url"] = base_url
+    if metadata:
+        for key in ("max_retries", "timeout", "anthropic_version", "beta"):
+            value = metadata.get(key)
+            if value is not None:
+                kwargs[key] = value
+    return kwargs
+
+
+async def _invoke_models_list(client: Any) -> Any:
+    models_service = getattr(client, "models", None)
+    if models_service is None:
+        raise RuntimeError("Anthropic client does not expose a models service")
+    list_callable = getattr(models_service, "list", None)
+    if not callable(list_callable):
+        raise RuntimeError("Anthropic client does not provide a list method for models")
+    result = list_callable()
+    if inspect.isawaitable(result):
+        return await result
+    return result
+
+
+class AnthropicProviderClient(ProviderClient):
+    """Fetch models from Anthropic using the official Python SDK."""
+
+    provider = "anthropic"
+    default_base_url = "https://api.anthropic.com"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+        client_factory: ClientFactory | None = None,
+    ) -> None:
+        super().__init__(
+            settings,
+            base_url=base_url,
+            api_key=api_key,
+            metadata=metadata,
+            transport=transport,
+        )
+        self._client_factory: ClientFactory = client_factory or _default_client_factory
+
+    @property
+    def base_url(self) -> str:
+        if self._base_url_override:
+            return self._base_url_override
+        api_base = getattr(self._settings, "anthropic_api_base", None)
+        return api_base or self.default_base_url
+
+    def _get_api_key(self) -> str | None:
+        if self._api_key_override:
+            return self._api_key_override
+        api_key = getattr(self._settings, "anthropic_api_key", None)
+        if isinstance(api_key, str) and api_key.strip():
+            return api_key.strip()
+        return None
+
+    async def list_models(self) -> list[ProviderModel]:
+        if AsyncAnthropic is None and self._client_factory is _default_client_factory:
+            self._logger.error(
+                "Anthropic SDK is not installed; cannot list models. Install it via 'pip install anthropic'."
+            )
+            return []
+
+        api_key = self._get_api_key()
+        if self.requires_api_key and not api_key:
+            self._logger.warning("Skipping %s provider because credentials are not configured", self.provider)
+            return []
+
+        client_kwargs = _build_client_kwargs(api_key, self.base_url, self.metadata)
+        try:
+            async with _client_context(self._client_factory, **client_kwargs) as client:
+                payload = await _invoke_models_list(client)
+        except AnthropicAPIError as exc:  # pragma: no cover - depends on SDK runtime
+            self._logger.error("Anthropic SDK request failed: %s", exc)
+            return []
+        except Exception:  # pragma: no cover - defensive catch-all
+            self._logger.exception("Unexpected error while fetching models from %s", self.provider)
+            return []
+        return self._parse_models(payload)
+
+    def _parse_models(self, payload: Any) -> list[ProviderModel]:
+        data_iterable = self._extract_model_entries(payload)
+        models: list[ProviderModel] = []
+        for entry in data_iterable:
+            mapping = self._normalise_entry(entry)
+            if not mapping:
+                continue
+            model_id = mapping.get("id")
+            if not model_id:
+                continue
+            name = mapping.get("display_name") or mapping.get("name") or model_id
+            metadata_keys = (
+                "type",
+                "display_name",
+                "context_window",
+                "max_context_length",
+                "input_token_limit",
+                "output_token_limit",
+                "default_voice",
+                "default_tool",
+                "default_prompt_template",
+                "aliases",
+                "beta",
+                "status",
+            )
+            metadata = {key: mapping.get(key) for key in metadata_keys if mapping.get(key) is not None}
+            pricing = mapping.get("pricing") or mapping.get("price")
+            if isinstance(pricing, Mapping):
+                pricing_data: dict[str, Any] | None = dict(pricing)
+            else:
+                pricing_data = None
+            context_window = self._coerce_int(
+                mapping.get("context_window")
+                or mapping.get("context_length")
+                or mapping.get("max_context_length")
+                or mapping.get("input_token_limit")
+            )
+            max_output_tokens = self._coerce_int(
+                mapping.get("max_output_tokens")
+                or mapping.get("output_token_limit")
+                or mapping.get("default_max_output_tokens")
+            )
+            status = mapping.get("status")
+            is_active: bool | None = None
+            if isinstance(status, str):
+                is_active = status.lower() in {"active", "available", "enabled"}
+            elif isinstance(mapping.get("active"), bool):
+                is_active = bool(mapping.get("active"))
+
+            models.append(
+                ProviderModel(
+                    provider=self.provider,
+                    id=str(model_id),
+                    name=str(name),
+                    description=mapping.get("description") or mapping.get("display_name"),
+                    context_window=context_window,
+                    max_output_tokens=max_output_tokens,
+                    pricing=pricing_data,
+                    is_active=is_active,
+                    metadata=metadata or None,
+                )
+            )
+        return models
+
+    def _additional_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        metadata_source = self.metadata
+        if isinstance(metadata_source, Mapping):
+            version = metadata_source.get("anthropic-version") or metadata_source.get("anthropic_version")
+            if version:
+                headers["anthropic-version"] = str(version)
+        return headers
+
+    def _extract_model_entries(self, payload: Any) -> Iterable[Any]:
+        if payload is None:
+            return []
+        if isinstance(payload, Mapping):
+            data = payload.get("data", [])
+        elif hasattr(payload, "data"):
+            data = getattr(payload, "data")
+        elif hasattr(payload, "model_dump"):
+            try:
+                dumped = payload.model_dump()
+            except Exception:  # pragma: no cover - defensive catch-all
+                dumped = {}
+            data = dumped.get("data", []) if isinstance(dumped, Mapping) else []
+        else:
+            data = []
+        if isinstance(data, Sequence):
+            return data
+        if isinstance(data, Iterable):
+            return list(data)
+        return []
+
+    def _normalise_entry(self, entry: Any) -> Mapping[str, Any]:
+        if isinstance(entry, Mapping):
+            return entry
+        if hasattr(entry, "model_dump"):
+            try:
+                dumped = entry.model_dump()
+                if isinstance(dumped, Mapping):
+                    return dumped
+            except Exception:  # pragma: no cover - defensive catch-all
+                pass
+        keys_of_interest = {
+            key: getattr(entry, key)
+            for key in (
+                "id",
+                "name",
+                "display_name",
+                "description",
+                "context_window",
+                "context_length",
+                "max_context_length",
+                "input_token_limit",
+                "output_token_limit",
+                "max_output_tokens",
+                "default_max_output_tokens",
+                "pricing",
+                "price",
+                "status",
+                "active",
+                "aliases",
+                "type",
+                "beta",
+                "default_voice",
+                "default_tool",
+                "default_prompt_template",
+            )
+            if hasattr(entry, key)
+        }
+        return {key: value for key, value in keys_of_interest.items() if value is not None}
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):  # pragma: no cover - defensive cast
+            return None
+
+
+__all__ = ["AnthropicProviderClient"]

--- a/pocketllm-backend/app/services/providers/catalogue.py
+++ b/pocketllm-backend/app/services/providers/catalogue.py
@@ -14,9 +14,12 @@ from typing import Any
 from app.core.config import Settings
 from app.schemas.providers import ProviderModel
 
+from .anthropic import AnthropicProviderClient
 from .base import ProviderClient
+from .deepseek import DeepSeekProviderClient
 from .groq import GroqProviderClient
 from .imagerouter import ImageRouterProviderClient
+from .mistral import MistralProviderClient
 from .openai import OpenAIProviderClient
 from .openrouter import OpenRouterProviderClient
 
@@ -56,9 +59,12 @@ class ProviderModelCatalogue:
             if client_factories is not None
             else {
                 "openai": OpenAIProviderClient,
+                "anthropic": AnthropicProviderClient,
+                "deepseek": DeepSeekProviderClient,
                 "groq": GroqProviderClient,
                 "openrouter": OpenRouterProviderClient,
                 "imagerouter": ImageRouterProviderClient,
+                "mistral": MistralProviderClient,
             }
         )
         self._cache_ttl_seconds = self._coerce_ttl(
@@ -271,6 +277,39 @@ class ProviderModelCatalogue:
             api_key=cleaned_imagerouter_key,
             metadata=None,
         )
+
+        anthropic_key = getattr(self._settings, "anthropic_api_key", None)
+        if isinstance(anthropic_key, str):
+            anthropic_key = anthropic_key.strip()
+        if anthropic_key:
+            fallbacks["anthropic"] = _ProviderConfig(
+                provider="anthropic",
+                base_url=getattr(self._settings, "anthropic_api_base", None),
+                api_key=anthropic_key,
+                metadata=None,
+            )
+
+        deepseek_key = getattr(self._settings, "deepseek_api_key", None)
+        if isinstance(deepseek_key, str):
+            deepseek_key = deepseek_key.strip()
+        if deepseek_key:
+            fallbacks["deepseek"] = _ProviderConfig(
+                provider="deepseek",
+                base_url=getattr(self._settings, "deepseek_api_base", None),
+                api_key=deepseek_key,
+                metadata=None,
+            )
+
+        mistral_key = getattr(self._settings, "mistral_api_key", None)
+        if isinstance(mistral_key, str):
+            mistral_key = mistral_key.strip()
+        if mistral_key:
+            fallbacks["mistral"] = _ProviderConfig(
+                provider="mistral",
+                base_url=getattr(self._settings, "mistral_api_base", None),
+                api_key=mistral_key,
+                metadata=None,
+            )
 
         return fallbacks
 

--- a/pocketllm-backend/app/services/providers/deepseek.py
+++ b/pocketllm-backend/app/services/providers/deepseek.py
@@ -1,0 +1,59 @@
+"""DeepSeek provider client implementation built on the OpenAI-compatible SDK."""
+
+from __future__ import annotations
+
+from typing import Mapping
+
+import httpx
+
+from app.core.config import Settings
+
+from .openai import ClientFactory, OpenAIProviderClient
+
+
+class DeepSeekProviderClient(OpenAIProviderClient):
+    """Fetch models from DeepSeek using the OpenAI-compatible Python SDK."""
+
+    provider = "deepseek"
+    default_base_url = "https://api.deepseek.com"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        metadata: Mapping[str, object] | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+        client_factory: ClientFactory | None = None,
+    ) -> None:
+        super().__init__(
+            settings,
+            base_url=base_url,
+            api_key=api_key,
+            metadata=metadata,
+            transport=transport,
+            client_factory=client_factory,
+        )
+
+    @property
+    def base_url(self) -> str:
+        if self._base_url_override:
+            return self._base_url_override
+        api_base = getattr(self._settings, "deepseek_api_base", None)
+        return api_base or self.default_base_url
+
+    def _get_api_key(self) -> str | None:
+        if self._api_key_override:
+            return self._api_key_override
+        api_key = getattr(self._settings, "deepseek_api_key", None)
+        if isinstance(api_key, str) and api_key.strip():
+            return api_key.strip()
+        return None
+
+    def _additional_headers(self) -> dict[str, str]:  # type: ignore[override]
+        # DeepSeek follows OpenAI's authentication model and does not require custom headers.
+        return {}
+
+
+__all__ = ["DeepSeekProviderClient"]

--- a/pocketllm-backend/app/services/providers/mistral.py
+++ b/pocketllm-backend/app/services/providers/mistral.py
@@ -1,0 +1,296 @@
+"""Mistral AI provider client implementation backed by the official SDK."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections.abc import Iterable, Mapping, Sequence
+from contextlib import asynccontextmanager
+from typing import Any, Callable
+
+import httpx
+
+from app.core.config import Settings
+from app.schemas.providers import ProviderModel
+
+from .base import ProviderClient
+
+try:  # pragma: no cover - exercised in production environments
+    from mistralai import Mistral
+except Exception:  # pragma: no cover - defensive fallback for environments without the SDK
+    Mistral = None  # type: ignore[assignment]
+
+try:  # pragma: no cover - exercised in production environments
+    from mistralai.exceptions import MistralAPIError
+except Exception:  # pragma: no cover - defensive fallback
+    class MistralAPIError(Exception):
+        """Fallback error raised when the Mistral SDK is unavailable."""
+
+
+ClientFactory = Callable[..., Any]
+
+
+def _default_client_factory(**kwargs: Any) -> Any:
+    if Mistral is None:
+        raise RuntimeError(
+            "The 'mistralai' package is required to use the Mistral provider client. Install it via 'pip install mistralai'."
+        )
+    return Mistral(**kwargs)
+
+
+async def _close_client(client: Any) -> None:
+    for attr in ("aclose", "close"):
+        close_callable = getattr(client, attr, None)
+        if callable(close_callable):
+            result = close_callable()
+            if inspect.isawaitable(result):
+                await result
+            return
+
+
+@asynccontextmanager
+async def _client_context(factory: ClientFactory, **kwargs: Any):
+    client = factory(**kwargs)
+    aenter = getattr(client, "__aenter__", None)
+    if callable(aenter):
+        try:
+            entered = aenter()
+            if inspect.isawaitable(entered):
+                entered = await entered
+            yield entered
+        finally:
+            aexit = getattr(client, "__aexit__", None)
+            if callable(aexit):
+                exit_result = aexit(None, None, None)
+                if inspect.isawaitable(exit_result):
+                    await exit_result
+    else:
+        try:
+            yield client
+        finally:
+            await _close_client(client)
+
+
+def _build_client_kwargs(
+    api_key: str | None,
+    base_url: str | None,
+    metadata: Mapping[str, Any] | None,
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
+    if api_key:
+        kwargs["api_key"] = api_key
+    # The SDK accepts server_url for overriding the API base.
+    if base_url:
+        kwargs["server_url"] = base_url
+    if metadata:
+        for key in ("timeout", "max_retries", "client_name"):
+            value = metadata.get(key)
+            if value is not None:
+                kwargs[key] = value
+    return kwargs
+
+
+async def _invoke_models_list(client: Any) -> Any:
+    models_service = getattr(client, "models", None)
+    if models_service is None:
+        raise RuntimeError("Mistral client does not expose a models service")
+    list_callable = getattr(models_service, "list", None)
+    if not callable(list_callable):
+        raise RuntimeError("Mistral client does not provide a list method for models")
+    if inspect.iscoroutinefunction(list_callable):
+        return await list_callable()
+    try:
+        return await asyncio.to_thread(list_callable)
+    except RuntimeError:
+        result = list_callable()
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
+
+class MistralProviderClient(ProviderClient):
+    """Fetch models from Mistral AI using the official Python SDK."""
+
+    provider = "mistral"
+    default_base_url = "https://api.mistral.ai"
+
+    def __init__(
+        self,
+        settings: Settings,
+        *,
+        base_url: str | None = None,
+        api_key: str | None = None,
+        metadata: Mapping[str, Any] | None = None,
+        transport: httpx.AsyncBaseTransport | None = None,
+        client_factory: ClientFactory | None = None,
+    ) -> None:
+        super().__init__(
+            settings,
+            base_url=base_url,
+            api_key=api_key,
+            metadata=metadata,
+            transport=transport,
+        )
+        self._client_factory: ClientFactory = client_factory or _default_client_factory
+
+    @property
+    def base_url(self) -> str:
+        if self._base_url_override:
+            return self._base_url_override
+        api_base = getattr(self._settings, "mistral_api_base", None)
+        return api_base or self.default_base_url
+
+    def _get_api_key(self) -> str | None:
+        if self._api_key_override:
+            return self._api_key_override
+        api_key = getattr(self._settings, "mistral_api_key", None)
+        if isinstance(api_key, str) and api_key.strip():
+            return api_key.strip()
+        return None
+
+    async def list_models(self) -> list[ProviderModel]:
+        if Mistral is None and self._client_factory is _default_client_factory:
+            self._logger.error(
+                "Mistral SDK is not installed; cannot list models. Install it via 'pip install mistralai'."
+            )
+            return []
+
+        api_key = self._get_api_key()
+        if self.requires_api_key and not api_key:
+            self._logger.warning("Skipping %s provider because credentials are not configured", self.provider)
+            return []
+
+        client_kwargs = _build_client_kwargs(api_key, self.base_url, self.metadata)
+        try:
+            async with _client_context(self._client_factory, **client_kwargs) as client:
+                payload = await _invoke_models_list(client)
+        except MistralAPIError as exc:  # pragma: no cover - depends on SDK runtime
+            self._logger.error("Mistral SDK request failed: %s", exc)
+            return []
+        except Exception:  # pragma: no cover - defensive catch-all
+            self._logger.exception("Unexpected error while fetching models from %s", self.provider)
+            return []
+        return self._parse_models(payload)
+
+    def _parse_models(self, payload: Any) -> list[ProviderModel]:
+        data_iterable = self._extract_model_entries(payload)
+        models: list[ProviderModel] = []
+        for entry in data_iterable:
+            mapping = self._normalise_entry(entry)
+            if not mapping:
+                continue
+            model_id = mapping.get("id")
+            if not model_id:
+                continue
+            name = mapping.get("name") or model_id
+            metadata_keys = (
+                "object",
+                "capabilities",
+                "aliases",
+                "created",
+                "deprecation",
+                "deprecation_replacement_model",
+                "default_model_temperature",
+                "owned_by",
+                "type",
+                "job",
+                "archived",
+                "root",
+            )
+            metadata = {key: mapping.get(key) for key in metadata_keys if mapping.get(key) is not None}
+            context_window = self._coerce_int(
+                mapping.get("max_context_length")
+                or mapping.get("context_window")
+                or mapping.get("context_length")
+            )
+            max_output_tokens = self._coerce_int(mapping.get("max_output_tokens") or mapping.get("max_tokens"))
+            archived = mapping.get("archived")
+            is_active: bool | None = None
+            if isinstance(archived, bool):
+                is_active = not archived
+
+            models.append(
+                ProviderModel(
+                    provider=self.provider,
+                    id=str(model_id),
+                    name=str(name),
+                    description=mapping.get("description"),
+                    context_window=context_window,
+                    max_output_tokens=max_output_tokens,
+                    pricing=None,
+                    is_active=is_active,
+                    metadata=metadata or None,
+                )
+            )
+        return models
+
+    def _extract_model_entries(self, payload: Any) -> Iterable[Any]:
+        if payload is None:
+            return []
+        if isinstance(payload, Mapping):
+            data = payload.get("data", [])
+        elif hasattr(payload, "data"):
+            data = getattr(payload, "data")
+        elif hasattr(payload, "model_dump"):
+            try:
+                dumped = payload.model_dump()
+            except Exception:  # pragma: no cover - defensive catch-all
+                dumped = {}
+            data = dumped.get("data", []) if isinstance(dumped, Mapping) else []
+        else:
+            data = []
+        if isinstance(data, Sequence):
+            return data
+        if isinstance(data, Iterable):
+            return list(data)
+        return []
+
+    def _normalise_entry(self, entry: Any) -> Mapping[str, Any]:
+        if isinstance(entry, Mapping):
+            return entry
+        if hasattr(entry, "model_dump"):
+            try:
+                dumped = entry.model_dump()
+                if isinstance(dumped, Mapping):
+                    return dumped
+            except Exception:  # pragma: no cover - defensive catch-all
+                pass
+        keys_of_interest = {
+            key: getattr(entry, key)
+            for key in (
+                "id",
+                "name",
+                "description",
+                "object",
+                "capabilities",
+                "aliases",
+                "created",
+                "deprecation",
+                "deprecation_replacement_model",
+                "default_model_temperature",
+                "max_context_length",
+                "context_window",
+                "context_length",
+                "max_output_tokens",
+                "max_tokens",
+                "owned_by",
+                "type",
+                "job",
+                "archived",
+                "root",
+            )
+            if hasattr(entry, key)
+        }
+        return {key: value for key, value in keys_of_interest.items() if value is not None}
+
+    @staticmethod
+    def _coerce_int(value: Any) -> int | None:
+        try:
+            if value is None:
+                return None
+            return int(value)
+        except (TypeError, ValueError):  # pragma: no cover - defensive cast
+            return None
+
+
+__all__ = ["MistralProviderClient"]

--- a/pocketllm-backend/requirements.txt
+++ b/pocketllm-backend/requirements.txt
@@ -5,6 +5,8 @@ pydantic-settings
 httpx
 groq
 openai
+anthropic>=0.3.0
+mistralai>=0.0.8
 langchain
 langchain-classic
 langchain-core

--- a/pocketllm-backend/tests/test_new_providers.py
+++ b/pocketllm-backend/tests/test_new_providers.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from app.schemas.providers import ProviderModel
+from app.services.providers.anthropic import AnthropicProviderClient
+from app.services.providers.catalogue import ProviderModelCatalogue
+from app.services.providers.deepseek import DeepSeekProviderClient
+from app.services.providers.mistral import MistralProviderClient
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    return "asyncio"
+
+
+class _AsyncModelListClient:
+    def __init__(self, payload: Any, *, error: Exception | None = None) -> None:
+        self._payload = payload
+        self._error = error
+        self.models = SimpleNamespace(list=self._list)
+        self.closed = False
+
+    async def _list(self) -> Any:
+        if self._error:
+            raise self._error
+        await asyncio.sleep(0)
+        return self._payload
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+class _SyncModelListClient:
+    def __init__(self, payload: Any, *, error: Exception | None = None) -> None:
+        self._payload = payload
+        self._error = error
+        self.models = SimpleNamespace(list=self._list)
+        self.closed = False
+
+    def _list(self) -> Any:
+        if self._error:
+            raise self._error
+        return self._payload
+
+    def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.anyio
+async def test_anthropic_client_parses_models() -> None:
+    payload = {
+        "data": [
+            {
+                "id": "claude-test",
+                "display_name": "Claude Test",
+                "description": "Test model",
+                "context_window": 200000,
+                "output_token_limit": 4096,
+                "pricing": {"input": 0.001, "output": 0.002},
+                "status": "active",
+            }
+        ]
+    }
+    settings = SimpleNamespace(anthropic_api_key=None, anthropic_api_base=None)
+    client = AnthropicProviderClient(
+        settings,
+        api_key="key",
+        client_factory=lambda **_: _AsyncModelListClient(payload),
+    )
+
+    models = await client.list_models()
+
+    assert len(models) == 1
+    model = models[0]
+    assert isinstance(model, ProviderModel)
+    assert model.provider == "anthropic"
+    assert model.id == "claude-test"
+    assert model.name == "Claude Test"
+    assert model.context_window == 200000
+    assert model.max_output_tokens == 4096
+    assert model.pricing == {"input": 0.001, "output": 0.002}
+    assert model.is_active is True
+
+
+@pytest.mark.anyio
+async def test_anthropic_client_handles_errors() -> None:
+    settings = SimpleNamespace(anthropic_api_key=None, anthropic_api_base=None)
+    client = AnthropicProviderClient(
+        settings,
+        api_key="key",
+        client_factory=lambda **_: _AsyncModelListClient({}, error=RuntimeError("boom")),
+    )
+
+    models = await client.list_models()
+
+    assert models == []
+
+
+@pytest.mark.anyio
+async def test_deepseek_client_inherits_openai_behaviour() -> None:
+    payload = {"data": [{"id": "deepseek-chat", "object": "model"}]}
+    settings = SimpleNamespace(deepseek_api_key=None, deepseek_api_base=None)
+
+    recording: dict[str, Any] = {}
+
+    def _factory(**kwargs: Any) -> _AsyncModelListClient:
+        recording.update(kwargs)
+        return _AsyncModelListClient(payload)
+
+    client = DeepSeekProviderClient(settings, api_key="key", client_factory=_factory)
+
+    models = await client.list_models()
+
+    assert len(models) == 1
+    assert models[0].provider == "deepseek"
+    assert recording.get("base_url") == client.base_url
+
+
+@pytest.mark.anyio
+async def test_mistral_client_parses_models() -> None:
+    payload = {
+        "data": [
+            {
+                "id": "open-mistral-7b",
+                "description": "General purpose model",
+                "max_context_length": 32768,
+                "aliases": ["mistral-7b"],
+                "capabilities": {"completion_chat": True},
+                "archived": False,
+            }
+        ]
+    }
+    settings = SimpleNamespace(mistral_api_key=None, mistral_api_base=None)
+
+    stub = _SyncModelListClient(payload)
+    client = MistralProviderClient(
+        settings,
+        api_key="key",
+        client_factory=lambda **_: stub,
+    )
+
+    models = await client.list_models()
+
+    assert len(models) == 1
+    model = models[0]
+    assert model.provider == "mistral"
+    assert model.id == "open-mistral-7b"
+    assert model.context_window == 32768
+    assert model.is_active is True
+    assert stub.closed is True
+
+
+@pytest.mark.anyio
+async def test_mistral_client_handles_errors() -> None:
+    settings = SimpleNamespace(mistral_api_key=None, mistral_api_base=None)
+    stub = _SyncModelListClient({}, error=RuntimeError("failure"))
+    client = MistralProviderClient(
+        settings,
+        api_key="key",
+        client_factory=lambda **_: stub,
+    )
+
+    models = await client.list_models()
+
+    assert models == []
+    assert stub.closed is True
+
+
+def test_catalogue_fallback_includes_new_providers() -> None:
+    settings = SimpleNamespace(
+        provider_catalogue_cache_ttl=0,
+        provider_catalogue_provider_timeout=10.0,
+        provider_catalogue_total_timeout=20.0,
+        openai_api_key=None,
+        openai_api_base=None,
+        groq_api_key=None,
+        groq_api_base=None,
+        openrouter_api_key=None,
+        openrouter_api_base=None,
+        openrouter_app_url=None,
+        openrouter_app_name=None,
+        imagerouter_api_key=None,
+        imagerouter_api_base=None,
+        anthropic_api_key="anthropic-key",
+        anthropic_api_base="https://api.anthropic.com",
+        deepseek_api_key="deepseek-key",
+        deepseek_api_base="https://api.deepseek.com",
+        mistral_api_key="mistral-key",
+        mistral_api_base="https://api.mistral.ai",
+    )
+
+    catalogue = ProviderModelCatalogue(settings)
+    fallbacks = catalogue._build_fallback_configs()
+
+    assert "anthropic" in fallbacks
+    assert fallbacks["anthropic"].api_key == "anthropic-key"
+    assert fallbacks["anthropic"].base_url == "https://api.anthropic.com"
+
+    assert "deepseek" in fallbacks
+    assert fallbacks["deepseek"].api_key == "deepseek-key"
+    assert fallbacks["deepseek"].base_url == "https://api.deepseek.com"
+
+    assert "mistral" in fallbacks
+    assert fallbacks["mistral"].api_key == "mistral-key"
+    assert fallbacks["mistral"].base_url == "https://api.mistral.ai"


### PR DESCRIPTION
## Summary
- add Anthropic, DeepSeek, and Mistral provider clients that wrap their official SDKs for model catalogue support
- register the new providers in settings, catalogue fallbacks, and package exports so they appear in the backend configuration
- add SDK dependencies and targeted unit tests covering success, error handling, and fallback behaviour

## Testing
- `pytest pocketllm-backend/tests/test_new_providers.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691437623ffc832d934ede6123c0206e)